### PR TITLE
Fix Next.js build by strengthening mock data layer

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -25,7 +25,7 @@ export default async function AdminPage() {
           {requests.map((request) => (
             <Card key={request.id}>
               <CardHeader className="flex items-center justify-between">
-                <CardTitle>{request.user.email}</CardTitle>
+                <CardTitle>{request.user?.email ?? request.userId}</CardTitle>
                 <Badge variant="outline">{request.status}</Badge>
               </CardHeader>
               <CardContent className="space-y-2 text-sm text-slate-600">

--- a/app/api/applications/[id]/route.ts
+++ b/app/api/applications/[id]/route.ts
@@ -13,7 +13,7 @@ export async function PATCH(request: Request, { params }: { params: { id: string
     where: { id: params.id },
     include: { gig: true }
   });
-  if (!application || application.gig.createdByUserId !== session.user.id) {
+  if (!application || !application.gig || application.gig.createdByUserId !== session.user.id) {
     return NextResponse.json({ error: "Not found" }, { status: 404 });
   }
 

--- a/app/api/me/route.ts
+++ b/app/api/me/route.ts
@@ -9,15 +9,21 @@ export async function GET() {
   }
   const user = await prisma.user.findUnique({
     where: { id: session.user.id },
-    select: {
-      id: true,
-      name: true,
-      email: true,
-      role: true,
-      promoter: { select: { verificationStatus: true } },
-      venue: { select: { verificationStatus: true } }
-    }
+    include: { promoter: true, venue: true }
   });
 
-  return NextResponse.json({ user });
+  if (!user) {
+    return NextResponse.json({ user: null }, { status: 200 });
+  }
+
+  return NextResponse.json({
+    user: {
+      id: user.id,
+      name: user.name,
+      email: user.email,
+      role: user.role,
+      promoter: user.promoter ? { verificationStatus: user.promoter.verificationStatus } : null,
+      venue: user.venue ? { verificationStatus: user.venue.verificationStatus } : null
+    }
+  });
 }

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -54,6 +54,10 @@ export default async function DashboardPage() {
     );
   }
 
+  const applications = user.applications ?? [];
+  const gigs = user.gigs ?? [];
+  const favorites = user.favorites ?? [];
+
   return (
     <div className="space-y-6">
       <div className="flex items-center justify-between">
@@ -72,12 +76,12 @@ export default async function DashboardPage() {
             <CardTitle>Recent applications</CardTitle>
           </CardHeader>
           <CardContent className="space-y-3 text-sm text-slate-600">
-            {user.applications.length === 0 ? (
+            {applications.length === 0 ? (
               <p>
                 No applications yet. Head to <Link className="text-brand" href="/gigs">Gigs</Link> to apply.
               </p>
             ) : (
-              user.applications.map((application) => (
+              applications.map((application) => (
                 <div key={application.id} className="flex items-center justify-between">
                   <span>{application.message.slice(0, 48)}...</span>
                   <Badge variant="outline">{application.status}</Badge>
@@ -94,10 +98,10 @@ export default async function DashboardPage() {
             <CardTitle>Your gigs</CardTitle>
           </CardHeader>
           <CardContent className="space-y-3 text-sm text-slate-600">
-            {user.gigs.length === 0 ? (
+            {gigs.length === 0 ? (
               <p>No gigs yet. Start by creating one.</p>
             ) : (
-              user.gigs.map((gig) => (
+              gigs.map((gig) => (
                 <div key={gig.id} className="flex items-center justify-between">
                   <span>{gig.title}</span>
                   <Badge variant="outline">{gig.status}</Badge>
@@ -117,10 +121,10 @@ export default async function DashboardPage() {
             <CardTitle>Saved gigs</CardTitle>
           </CardHeader>
           <CardContent className="space-y-3 text-sm text-slate-600">
-            {user.favorites.length === 0 ? (
+            {favorites.length === 0 ? (
               <p>You have not saved any gigs yet.</p>
             ) : (
-              user.favorites.map((favorite) => (
+              favorites.map((favorite) => (
                 <div key={favorite.id}>{favorite.gigId ? `Gig: ${favorite.gigId}` : `Venue: ${favorite.venueId}`}</div>
               ))
             )}

--- a/app/gigs/page.tsx
+++ b/app/gigs/page.tsx
@@ -64,7 +64,6 @@ export default function GigsPage({ searchParams }: { searchParams: Record<string
         <p className="text-sm text-slate-600">Filter by location, compensation, and more.</p>
       </div>
       <Suspense key={JSON.stringify(searchParams)} fallback={<p>Loading gigs...</p>}>
-        {/* @ts-expect-error Server Component */}
         <GigsList searchParams={searchParams} />
       </Suspense>
     </section>

--- a/app/verification/page.tsx
+++ b/app/verification/page.tsx
@@ -32,7 +32,8 @@ async function submitVerification(formData: FormData) {
       userId: session.user.id,
       roleRequested: parsed.data.role,
       message: parsed.data.message,
-      documents: parsed.data.documents
+      documents: parsed.data.documents,
+      status: "PENDING"
     }
   });
   redirect("/dashboard");

--- a/components/ui/badge.tsx
+++ b/components/ui/badge.tsx
@@ -3,16 +3,19 @@ import { cn } from "@/lib/utils";
 
 export function Badge({
   children,
-  variant = "default"
+  variant = "default",
+  className
 }: {
   children: React.ReactNode;
   variant?: "default" | "outline";
+  className?: string;
 }) {
   return (
     <span
       className={cn(
         "inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium",
-        variant === "default" ? "bg-brand/10 text-brand" : "border border-slate-200 text-slate-700"
+        variant === "default" ? "bg-brand/10 text-brand" : "border border-slate-200 text-slate-700",
+        className
       )}
     >
       {children}

--- a/lib/dataStore.ts
+++ b/lib/dataStore.ts
@@ -217,6 +217,38 @@ export async function getComedianProfile(userId: string): Promise<ComedianProfil
   return record ? mapComedian(record) : null;
 }
 
+interface CreateComedianProfileInput {
+  userId: string;
+  stageName: string;
+}
+
+export async function createComedianProfile(input: CreateComedianProfileInput): Promise<ComedianProfile> {
+  const snapshot = await loadSnapshot();
+  const now = nowIso();
+  const record: ComedianProfileRecord = {
+    userId: input.userId,
+    stageName: input.stageName,
+    bio: null,
+    credits: null,
+    website: null,
+    reelUrl: null,
+    instagram: null,
+    travelRadiusMiles: null,
+    homeCity: null,
+    homeState: null,
+    createdAt: now,
+    updatedAt: now
+  };
+  const index = snapshot.comedianProfiles.findIndex((profile) => profile.userId === input.userId);
+  if (index >= 0) {
+    snapshot.comedianProfiles[index] = record;
+  } else {
+    snapshot.comedianProfiles.push(record);
+  }
+  await persist(snapshot);
+  return mapComedian(record);
+}
+
 export async function getPromoterProfile(userId: string): Promise<PromoterProfile | null> {
   const snapshot = await loadSnapshot();
   const record = snapshot.promoterProfiles.find((profile) => profile.userId === userId);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     "strict": true,
     "noEmit": true,
     "module": "ESNext",
-    "moduleResolution": "NodeNext",
+    "moduleResolution": "Bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",

--- a/types/nodemailer.d.ts
+++ b/types/nodemailer.d.ts
@@ -1,0 +1,1 @@
+declare module "nodemailer";


### PR DESCRIPTION
## Summary
- switch TypeScript to bundler module resolution and add a stub nodemailer type so the app compiles cleanly
- extend the in-memory prisma mock to cover comedian profile creation and typed relation includes
- harden pages and API routes against missing relations and ensure verification requests default to pending

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d745652100832398077e1d2999d126