### PR TITLE
Harden storage, auth, and API safeguards

### DIFF
--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -2,8 +2,13 @@ import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { loginSchema } from "@/lib/zodSchemas";
 import { compare } from "bcryptjs";
+import { rateLimit } from "@/lib/rateLimit";
 
 export async function POST(request: Request) {
+  const identifier = request.headers.get("x-forwarded-for") ?? request.headers.get("x-real-ip") ?? "anonymous";
+  if (!rateLimit(`auth:login:${identifier}`)) {
+    return NextResponse.json({ error: "Too many requests" }, { status: 429 });
+  }
   const body = await request.json();
   const parsed = loginSchema.safeParse(body);
   if (!parsed.success) {

--- a/lib/sanitize.ts
+++ b/lib/sanitize.ts
@@ -1,0 +1,14 @@
+const dangerousTags = /(script|style|iframe|object|embed|link|meta)/gi;
+const eventAttributes = /on\w+=\s*("[^"]*"|'[^']*'|[^\s>]+)/gi;
+const javascriptHref = /href=\s*("javascript:[^"]*"|'javascript:[^']*'|javascript:[^\s>]+)/gi;
+
+export function sanitizeHtml(input: string): string {
+  if (!input) {
+    return "";
+  }
+  let sanitized = input.replace(/</g, "&lt;").replace(/>/g, "&gt;");
+  sanitized = sanitized.replace(dangerousTags, "");
+  sanitized = sanitized.replace(eventAttributes, "");
+  sanitized = sanitized.replace(javascriptHref, "");
+  return sanitized;
+}

--- a/lib/uploads.ts
+++ b/lib/uploads.ts
@@ -2,7 +2,7 @@ import { promises as fs } from "fs";
 import path from "path";
 import crypto from "crypto";
 
-const uploadDir = path.join(process.cwd(), "uploads");
+const uploadDir = path.join(process.cwd(), "public", "uploads");
 
 export async function ensureUploadDir() {
   await fs.mkdir(uploadDir, { recursive: true });


### PR DESCRIPTION
## Summary
- ensure uploads are written under public/uploads so generated URLs resolve
- harden the JSON datastore bootstrap and sanitise persisted gig/application content while tightening session handling and gig validation
- expand rate limiting, add gig pagination metadata, and share a reusable HTML sanitizer helper

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68de12099ecc8323b099ae7e477b7bce