### PR TITLE
Add comedian directory with video showcases and show history

### DIFF
--- a/app/comedians/[userId]/page.tsx
+++ b/app/comedians/[userId]/page.tsx
@@ -1,0 +1,266 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { prisma } from "@/lib/prisma";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import {
+  ArrowLeft,
+  CalendarDays,
+  ExternalLink,
+  MapPin,
+  Mic2,
+  Play,
+  Sparkles,
+  Video
+} from "lucide-react";
+
+const longDate = new Intl.DateTimeFormat("en-US", {
+  month: "long",
+  day: "numeric",
+  year: "numeric"
+});
+
+function embedYouTube(url: string) {
+  try {
+    const parsed = new URL(url);
+    if (parsed.hostname.includes("youtube.com")) {
+      const videoId = parsed.searchParams.get("v");
+      if (videoId) {
+        return `https://www.youtube.com/embed/${videoId}`;
+      }
+      const paths = parsed.pathname.split("/").filter(Boolean);
+      if (paths[0] === "embed" && paths[1]) return url;
+    }
+    if (parsed.hostname === "youtu.be") {
+      const segments = parsed.pathname.split("/").filter(Boolean);
+      if (segments[0]) {
+        return `https://www.youtube.com/embed/${segments[0]}`;
+      }
+    }
+  } catch (error) {
+    return null;
+  }
+  return null;
+}
+
+function toInstagramUrl(handle: string) {
+  return `https://www.instagram.com/${handle.replace(/^@/, "")}`;
+}
+
+function toTikTokUrl(handle: string) {
+  return `https://www.tiktok.com/@${handle.replace(/^@/, "")}`;
+}
+
+function formatLocation(city: string | null, state: string | null) {
+  if (!city && !state) return null;
+  if (city && state) return `${city}, ${state}`;
+  return city ?? state ?? null;
+}
+
+export default async function ComedianProfilePage({ params }: { params: { userId: string } }) {
+  const comedian = await prisma.comedian.findUnique({
+    where: { userId: params.userId },
+    include: {
+      user: true,
+      videos: { orderBy: { postedAt: "desc" } },
+      appearances: { orderBy: { performedAt: "desc" } }
+    }
+  });
+
+  if (!comedian) {
+    notFound();
+  }
+
+  const location = formatLocation(comedian.homeCity, comedian.homeState);
+
+  return (
+    <div className="space-y-8">
+      <Button asChild variant="ghost" className="px-0 text-brand hover:text-brand-dark">
+        <Link href="/comedians" className="inline-flex items-center gap-2">
+          <ArrowLeft className="h-4 w-4" /> Back to comedians
+        </Link>
+      </Button>
+
+      <section className="rounded-3xl border border-slate-200/80 bg-white/80 p-8 shadow-sm">
+        <div className="flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <Badge variant="outline" className="border-brand/30 text-brand">
+                Verified talent profile
+              </Badge>
+              <h1 className="text-4xl font-semibold text-slate-900">{comedian.stageName}</h1>
+              {comedian.user?.name && <p className="text-sm text-slate-500">Legal name: {comedian.user.name}</p>}
+            </div>
+            <div className="flex flex-wrap items-center gap-3 text-sm text-slate-600">
+              <span className="inline-flex items-center gap-1">
+                <Mic2 className="h-4 w-4 text-brand" /> Comedian
+              </span>
+              {location && (
+                <span className="inline-flex items-center gap-1">
+                  <MapPin className="h-4 w-4 text-brand" /> {location}
+                </span>
+              )}
+              {typeof comedian.travelRadiusMiles === "number" && (
+                <span className="inline-flex items-center gap-1">
+                  <Sparkles className="h-4 w-4 text-amber-500" /> Travels {comedian.travelRadiusMiles} miles
+                </span>
+              )}
+            </div>
+            <div className="flex flex-wrap gap-3 text-sm font-medium text-brand">
+              {comedian.website && (
+                <a href={comedian.website} target="_blank" rel="noreferrer" className="inline-flex items-center gap-1 hover:underline">
+                  <ExternalLink className="h-4 w-4" /> Website
+                </a>
+              )}
+              {comedian.reelUrl && (
+                <a href={comedian.reelUrl} target="_blank" rel="noreferrer" className="inline-flex items-center gap-1 hover:underline">
+                  <Play className="h-4 w-4" /> Reel
+                </a>
+              )}
+              {comedian.instagram && (
+                <a href={toInstagramUrl(comedian.instagram)} target="_blank" rel="noreferrer" className="inline-flex items-center gap-1 hover:underline">
+                  <ExternalLink className="h-4 w-4" /> Instagram
+                </a>
+              )}
+              {comedian.tiktokHandle && (
+                <a href={toTikTokUrl(comedian.tiktokHandle)} target="_blank" rel="noreferrer" className="inline-flex items-center gap-1 hover:underline">
+                  <ExternalLink className="h-4 w-4" /> TikTok
+                </a>
+              )}
+              {comedian.youtubeChannel && (
+                <a href={comedian.youtubeChannel} target="_blank" rel="noreferrer" className="inline-flex items-center gap-1 hover:underline">
+                  <ExternalLink className="h-4 w-4" /> YouTube
+                </a>
+              )}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="grid gap-6 lg:grid-cols-[1.2fr_1fr]">
+        <Card className="border-slate-200/80 bg-white/80">
+          <CardHeader>
+            <CardTitle>About {comedian.stageName}</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4 text-sm text-slate-600">
+            {comedian.bio ? <p>{comedian.bio}</p> : <p className="text-slate-400">No bio has been added yet.</p>}
+            <div className="space-y-1 text-sm">
+              <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Credits</p>
+              <p>{comedian.credits ?? "No credits listed."}</p>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card className="border-slate-200/80 bg-white/80">
+          <CardHeader>
+            <CardTitle>Booking quick facts</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2 text-sm text-slate-600">
+            <p>
+              <span className="font-medium text-slate-700">Primary location:</span> {location ?? "Not specified"}
+            </p>
+            <p>
+              <span className="font-medium text-slate-700">Travel radius:</span>{" "}
+              {typeof comedian.travelRadiusMiles === "number" ? `${comedian.travelRadiusMiles} miles` : "Not provided"}
+            </p>
+            <p>
+              <span className="font-medium text-slate-700">Contact:</span> {comedian.user?.email ?? "See promoter portal"}
+            </p>
+          </CardContent>
+        </Card>
+      </section>
+
+      <section className="space-y-4">
+        <div className="flex items-center justify-between">
+          <h2 className="text-xl font-semibold text-slate-900">Featured clips</h2>
+          <Badge variant="secondary" className="bg-brand/10 text-brand">
+            {comedian.videos?.length ?? 0} posted
+          </Badge>
+        </div>
+        {comedian.videos && comedian.videos.length > 0 ? (
+          <div className="grid gap-6 md:grid-cols-2">
+            {comedian.videos.map((video) => {
+              const embedUrl = video.platform === "YOUTUBE" ? embedYouTube(video.url) : null;
+              return (
+                <Card key={video.id} className="overflow-hidden border-slate-200/80 bg-white/80">
+                  <CardHeader>
+                    <CardTitle className="text-base">{video.title}</CardTitle>
+                    <p className="text-xs uppercase tracking-wide text-slate-400">{video.platform}</p>
+                  </CardHeader>
+                  <CardContent className="space-y-3 text-sm text-slate-600">
+                    {embedUrl ? (
+                      <div className="aspect-video overflow-hidden rounded-lg border border-slate-200/80">
+                        <iframe
+                          src={embedUrl}
+                          title={video.title}
+                          className="h-full w-full"
+                          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                          allowFullScreen
+                        />
+                      </div>
+                    ) : (
+                      <a
+                        href={video.url}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="inline-flex items-center gap-2 text-brand hover:text-brand-dark"
+                      >
+                        <span className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-brand/10 text-brand">
+                          {video.platform === "YOUTUBE" ? <Play className="h-4 w-4" /> : <Video className="h-4 w-4" />}
+                        </span>
+                        Watch on {video.platform}
+                      </a>
+                    )}
+                    <p className="text-xs text-slate-400">Shared {longDate.format(video.postedAt)}</p>
+                  </CardContent>
+                </Card>
+              );
+            })}
+          </div>
+        ) : (
+          <Card className="border-slate-200/80 bg-white/80">
+            <CardContent className="py-8 text-center text-sm text-slate-400">
+              No video clips have been posted yet.
+            </CardContent>
+          </Card>
+        )}
+      </section>
+
+      <section className="space-y-4">
+        <div className="flex items-center justify-between">
+          <h2 className="text-xl font-semibold text-slate-900">Show history</h2>
+          <Badge variant="secondary" className="bg-emerald-100 text-emerald-700">
+            {comedian.appearances?.length ?? 0} completed shows
+          </Badge>
+        </div>
+        {comedian.appearances && comedian.appearances.length > 0 ? (
+          <div className="grid gap-3">
+            {comedian.appearances.map((appearance) => (
+              <Card key={appearance.id} className="border-slate-200/80 bg-white/80">
+                <CardContent className="flex flex-wrap items-center justify-between gap-3 py-4 text-sm text-slate-600">
+                  <div>
+                    <p className="text-base font-semibold text-slate-900">{appearance.showName}</p>
+                    <p className="text-xs text-slate-500">
+                      {appearance.venueName} • {appearance.city}, {appearance.state}
+                    </p>
+                  </div>
+                  <div className="flex items-center gap-2 text-xs text-slate-500">
+                    <CalendarDays className="h-4 w-4" />
+                    {longDate.format(appearance.performedAt)}
+                  </div>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        ) : (
+          <Card className="border-slate-200/80 bg-white/80">
+            <CardContent className="py-8 text-center text-sm text-slate-400">
+              No verified shows recorded yet.
+            </CardContent>
+          </Card>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/app/comedians/page.tsx
+++ b/app/comedians/page.tsx
@@ -1,0 +1,163 @@
+import Link from "next/link";
+import { prisma } from "@/lib/prisma";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { CalendarDays, MapPin, Play, Video } from "lucide-react";
+
+const dateFormatter = new Intl.DateTimeFormat("en-US", {
+  month: "short",
+  day: "numeric",
+  year: "numeric"
+});
+
+function formatLocation(city: string | null, state: string | null) {
+  if (!city && !state) return null;
+  if (city && state) return `${city}, ${state}`;
+  return city ?? state ?? null;
+}
+
+function tiktokUrl(handle: string) {
+  const normalized = handle.startsWith("@") ? handle.slice(1) : handle;
+  return `https://www.tiktok.com/@${normalized}`;
+}
+
+export default async function ComediansPage() {
+  const comedians = await prisma.comedian.findMany({
+    include: {
+      user: true,
+      videos: { take: 2, orderBy: { postedAt: "desc" } },
+      appearances: { take: 3, orderBy: { performedAt: "desc" } }
+    }
+  });
+
+  return (
+    <div className="space-y-10">
+      <div className="space-y-3">
+        <Badge variant="outline" className="w-fit border-brand/40 text-brand">
+          Talent directory
+        </Badge>
+        <h1 className="text-3xl font-semibold text-slate-900">Featured comedians</h1>
+        <p className="max-w-2xl text-sm text-slate-600">
+          Discover detailed profiles with reels, TikTok clips, YouTube highlights, and proof of shows already performed
+          across the network.
+        </p>
+      </div>
+
+      <div className="grid gap-6 md:grid-cols-2">
+        {comedians.map((comedian) => {
+          const location = formatLocation(comedian.homeCity, comedian.homeState);
+          return (
+            <Card key={comedian.userId} className="flex h-full flex-col justify-between border-slate-200/80 bg-white/80">
+              <CardHeader className="space-y-2">
+                <div className="flex items-start justify-between gap-4">
+                  <div className="space-y-1">
+                    <CardTitle className="text-xl font-semibold text-slate-900">
+                      {comedian.stageName}
+                    </CardTitle>
+                    {comedian.user?.name && <p className="text-sm text-slate-500">{comedian.user.name}</p>}
+                  </div>
+                  <Badge variant="outline" className="border-brand/30 text-[10px] uppercase tracking-wide text-brand">
+                    Comedian
+                  </Badge>
+                </div>
+                {location && (
+                  <p className="flex items-center gap-1 text-xs text-slate-500">
+                    <MapPin className="h-3.5 w-3.5 text-brand" />
+                    {location}
+                    {comedian.travelRadiusMiles ? ` • Travels ${comedian.travelRadiusMiles} mi` : null}
+                  </p>
+                )}
+                {comedian.bio && <p className="text-sm text-slate-600">{comedian.bio}</p>}
+                <div className="flex flex-wrap gap-2 text-xs font-medium text-brand">
+                  {comedian.website && (
+                    <a href={comedian.website} target="_blank" rel="noreferrer" className="hover:underline">
+                      Website
+                    </a>
+                  )}
+                  {comedian.instagram && (
+                    <a
+                      href={`https://www.instagram.com/${comedian.instagram.replace(/^@/, "")}`}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="hover:underline"
+                    >
+                      Instagram
+                    </a>
+                  )}
+                  {comedian.tiktokHandle && (
+                    <a href={tiktokUrl(comedian.tiktokHandle)} target="_blank" rel="noreferrer" className="hover:underline">
+                      TikTok
+                    </a>
+                  )}
+                  {comedian.youtubeChannel && (
+                    <a href={comedian.youtubeChannel} target="_blank" rel="noreferrer" className="hover:underline">
+                      YouTube
+                    </a>
+                  )}
+                </div>
+              </CardHeader>
+              <CardContent className="space-y-5 text-sm text-slate-600">
+                <div className="space-y-2">
+                  <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Featured clips</p>
+                  {comedian.videos && comedian.videos.length > 0 ? (
+                    <ul className="space-y-2">
+                      {comedian.videos.map((video) => (
+                        <li key={video.id}>
+                          <a
+                            href={video.url}
+                            target="_blank"
+                            rel="noreferrer"
+                            className="flex items-center gap-2 text-sm text-brand transition hover:text-brand-dark"
+                          >
+                            <span className="inline-flex h-7 w-7 items-center justify-center rounded-full bg-brand/10 text-brand">
+                              {video.platform === "YOUTUBE" ? <Play className="h-3.5 w-3.5" /> : <Video className="h-3.5 w-3.5" />}
+                            </span>
+                            <span className="flex-1">
+                              {video.title}
+                              <span className="ml-2 text-xs uppercase tracking-wide text-slate-400">{video.platform}</span>
+                            </span>
+                          </a>
+                        </li>
+                      ))}
+                    </ul>
+                  ) : (
+                    <p className="text-xs text-slate-400">No clips shared yet.</p>
+                  )}
+                </div>
+
+                <div className="space-y-2">
+                  <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Recent shows</p>
+                  {comedian.appearances && comedian.appearances.length > 0 ? (
+                    <ul className="space-y-2 text-sm">
+                      {comedian.appearances.map((appearance) => (
+                        <li key={appearance.id} className="flex items-start justify-between gap-3">
+                          <div>
+                            <p className="font-medium text-slate-700">{appearance.showName}</p>
+                            <p className="text-xs text-slate-500">
+                              {appearance.venueName} • {appearance.city}, {appearance.state}
+                            </p>
+                          </div>
+                          <span className="flex items-center gap-1 text-xs text-slate-500">
+                            <CalendarDays className="h-3.5 w-3.5" />
+                            {dateFormatter.format(appearance.performedAt)}
+                          </span>
+                        </li>
+                      ))}
+                    </ul>
+                  ) : (
+                    <p className="text-xs text-slate-400">No shows logged yet.</p>
+                  )}
+                </div>
+
+                <Button asChild variant="outline" className="w-full border-brand/40 text-brand">
+                  <Link href={`/comedians/${comedian.userId}`}>View full profile</Link>
+                </Button>
+              </CardContent>
+            </Card>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/app/the-funny/page.tsx
+++ b/app/the-funny/page.tsx
@@ -440,11 +440,19 @@ const Pricing = () => (
 const FAQ = () => (
   <section id="faq" className="mx-auto max-w-7xl px-4 py-12">
     <h3 className="mb-6 text-2xl font-bold">FAQ</h3>
-    <Accordion items={[
-      { q: "How do promoter/venue verifications work?", a: "We verify business details and a valid contact so comics know they\'re submitting to legit gigs." },
-      { q: "Is there a fee to submit avails?", a: "Free plan includes 3 submissions/month; Pro unlocks unlimited." },
-      { q: "Do you handle payments?", a: "Venues pay comics directly; we\'re rolling out optional escrow and invoice tools soon." },
-    ]} />
+    <Accordion
+      items={[
+        {
+          q: "How do promoter/venue verifications work?",
+          a: "We verify business details and a valid contact so comics know they&apos;re submitting to legit gigs."
+        },
+        { q: "Is there a fee to submit avails?", a: "Free plan includes 3 submissions/month; Pro unlocks unlimited." },
+        {
+          q: "Do you handle payments?",
+          a: "Venues pay comics directly; we&apos;re rolling out optional escrow and invoice tools soon."
+        }
+      ]}
+    />
   </section>
 );
 
@@ -454,7 +462,7 @@ const FinalCTA = () => (
     <div className="absolute inset-0 -z-10 bg-gradient-to-br from-indigo-600 via-indigo-500 to-fuchsia-500"/>
     <div className="mx-auto max-w-7xl px-4 py-14 text-white">
       <h3 className="text-3xl font-extrabold">Ready to get funny?</h3>
-      <p className="mt-2 max-w-2xl text-indigo-100">Join the network, post gigs, and fill rooms. It\'s free to start and takes 60 seconds.</p>
+      <p className="mt-2 max-w-2xl text-indigo-100">Join the network, post gigs, and fill rooms. It&apos;s free to start and takes 60 seconds.</p>
       <div className="mt-5 flex flex-wrap gap-3">
         <a className={`${btn.base} bg-white text-gray-900`} href="#signup">Create free account</a>
         <a className={`${btn.base} ${btn.ghost} border border-white/30`} href="#demo">See how it works</a>

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -20,6 +20,9 @@ export async function Navbar() {
           <Link className="transition hover:text-brand" href="/gigs">
             Gigs
           </Link>
+          <Link className="transition hover:text-brand" href="/comedians">
+            Comedians
+          </Link>
           {user?.role === "ADMIN" && (
             <Link className="transition hover:text-brand" href="/admin">
               Admin

--- a/data/database.json
+++ b/data/database.json
@@ -58,6 +58,8 @@
       "website": "https://caseycomic.example.com",
       "reelUrl": "https://youtu.be/example",
       "instagram": "@caseycomic",
+      "tiktokHandle": "@caseycomic",
+      "youtubeChannel": "https://www.youtube.com/@caseycomic",
       "travelRadiusMiles": 200,
       "homeCity": "Chicago",
       "homeState": "IL",
@@ -72,11 +74,89 @@
       "website": null,
       "reelUrl": null,
       "instagram": "@corycomic",
+      "tiktokHandle": "@corycomic",
+      "youtubeChannel": "https://www.youtube.com/@corycomic",
       "travelRadiusMiles": 150,
       "homeCity": "Milwaukee",
       "homeState": "WI",
       "createdAt": "2024-01-05T12:00:00.000Z",
       "updatedAt": "2024-03-02T12:00:00.000Z"
+    }
+  ],
+  "comedianVideos": [
+    {
+      "id": "video-casey-1",
+      "comedianUserId": "user-comic1",
+      "title": "Friday crowd work highlight",
+      "platform": "YOUTUBE",
+      "url": "https://www.youtube.com/watch?v=caseyclip1",
+      "postedAt": "2024-02-15T12:00:00.000Z"
+    },
+    {
+      "id": "video-casey-2",
+      "comedianUserId": "user-comic1",
+      "title": "TikTok: Late night train bits",
+      "platform": "TIKTOK",
+      "url": "https://www.tiktok.com/@caseycomic/video/1234567890",
+      "postedAt": "2024-03-05T12:00:00.000Z"
+    },
+    {
+      "id": "video-cory-1",
+      "comedianUserId": "user-comic2",
+      "title": "Corporate clean five",
+      "platform": "YOUTUBE",
+      "url": "https://www.youtube.com/watch?v=coryclip1",
+      "postedAt": "2024-01-28T12:00:00.000Z"
+    },
+    {
+      "id": "video-cory-2",
+      "comedianUserId": "user-comic2",
+      "title": "TikTok: Storytime sprint",
+      "platform": "TIKTOK",
+      "url": "https://www.tiktok.com/@corycomic/video/987654321",
+      "postedAt": "2024-03-12T12:00:00.000Z"
+    }
+  ],
+  "comedianAppearances": [
+    {
+      "id": "appearance-casey-1",
+      "comedianUserId": "user-comic1",
+      "showName": "Laugh Factory Showcase",
+      "venueName": "Laugh Factory",
+      "city": "Chicago",
+      "state": "IL",
+      "performedAt": "2024-02-01T01:00:00.000Z",
+      "gigId": "gig-1"
+    },
+    {
+      "id": "appearance-casey-2",
+      "comedianUserId": "user-comic1",
+      "showName": "High Plains Festival",
+      "venueName": "Main Stage",
+      "city": "Denver",
+      "state": "CO",
+      "performedAt": "2023-08-18T03:00:00.000Z",
+      "gigId": null
+    },
+    {
+      "id": "appearance-cory-1",
+      "comedianUserId": "user-comic2",
+      "showName": "Corporate Happy Hour",
+      "venueName": "Skyline HQ",
+      "city": "Chicago",
+      "state": "IL",
+      "performedAt": "2024-02-22T23:00:00.000Z",
+      "gigId": "gig-2"
+    },
+    {
+      "id": "appearance-cory-2",
+      "comedianUserId": "user-comic2",
+      "showName": "Riverwest Comedy Night",
+      "venueName": "The Harbor Room",
+      "city": "Milwaukee",
+      "state": "WI",
+      "performedAt": "2024-01-12T02:00:00.000Z",
+      "gigId": null
     }
   ],
   "promoterProfiles": [

--- a/types/database.ts
+++ b/types/database.ts
@@ -23,11 +23,35 @@ export interface ComedianProfileRecord {
   website: string | null;
   reelUrl: string | null;
   instagram: string | null;
+  tiktokHandle: string | null;
+  youtubeChannel: string | null;
   travelRadiusMiles: number | null;
   homeCity: string | null;
   homeState: string | null;
   createdAt: string;
   updatedAt: string;
+}
+
+export type ComedianVideoPlatform = "YOUTUBE" | "TIKTOK";
+
+export interface ComedianVideoRecord {
+  id: string;
+  comedianUserId: string;
+  title: string;
+  platform: ComedianVideoPlatform;
+  url: string;
+  postedAt: string;
+}
+
+export interface ComedianAppearanceRecord {
+  id: string;
+  comedianUserId: string;
+  showName: string;
+  venueName: string;
+  city: string;
+  state: string;
+  performedAt: string;
+  gigId: string | null;
 }
 
 export interface PromoterProfileRecord {
@@ -110,6 +134,8 @@ export interface FavoriteRecord {
 export interface DatabaseSnapshot {
   users: UserRecord[];
   comedianProfiles: ComedianProfileRecord[];
+  comedianVideos: ComedianVideoRecord[];
+  comedianAppearances: ComedianAppearanceRecord[];
   promoterProfiles: PromoterProfileRecord[];
   venueProfiles: VenueProfileRecord[];
   gigs: GigRecord[];


### PR DESCRIPTION
## Summary
- add a public comedians directory with featured clips and recent show history
- create detailed comedian profile pages with video embeds, socials, and booking details
- extend the datastore schema with social handles, video clips, and appearance records while fixing an existing lint issue

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68de1520a4a08323adee70b059b7c047