### PR TITLE
Refocus landing page on professional message board

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,258 +1,264 @@
-import Image from "next/image";
 import Link from "next/link";
-import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { HeroBackground } from "@/components/ui/HeroBackground";
 import { Icon } from "@/components/ui/Icon";
 
-const roles = [
+const primaryActions = [
   {
-    title: "Comedian",
-    description: "Discover gigs curated for your style and apply in a few clicks.",
+    label: "Join as comedian",
+    description: "Lock in bookings faster with verified promoter and venue listings.",
     href: "/auth/sign-up?role=COMEDIAN"
   },
   {
-    title: "Promoter",
-    description: "Post paid gigs and manage applicants once you are verified.",
+    label: "Join as promoter",
+    description: "Post rooms, share run-of-show details, and manage applicants in one place.",
     href: "/auth/sign-up?role=PROMOTER"
   },
   {
-    title: "Venue",
-    description: "Showcase your rooms, publish shows, and keep talent booked.",
+    label: "Join as venue",
+    description: "Keep your calendar full by showcasing specs, payouts, and tech requirements.",
     href: "/auth/sign-up?role=VENUE"
-  },
-  {
-    title: "Fan",
-    description: "Save upcoming shows and follow your favorite comedians.",
-    href: "/auth/sign-up?role=FAN"
   }
 ];
 
-const testimonialHighlights = [
+const boardThreads = [
   {
-    title: "Verified community",
-    description: "Identity checks for promoters and venues keep comedians safe and informed.",
+    title: "Looking for a late-night host in Chicago",
+    excerpt:
+      "Skyline Rooms needs a seasoned comic to host our Friday midnight mic. Share your tape and weekday availability.",
+    tags: ["Booking", "Chicago"],
+    replies: 12,
+    updated: "12 minutes ago"
+  },
+  {
+    title: "Room share: fully equipped black box in Austin",
+    excerpt:
+      "200-seat room available Sunday through Tuesday. Lights, sound, and door staff included. DM for rate sheet.",
+    tags: ["Venue", "Texas"],
+    replies: 6,
+    updated: "47 minutes ago"
+  },
+  {
+    title: "Workshop: building a tight festival set",
+    excerpt:
+      "Share feedback on 7-minute festival-ready sets. Recording swaps encouraged; constructive notes required.",
+    tags: ["Craft", "Feedback"],
+    replies: 18,
+    updated: "1 hour ago"
+  }
+];
+
+const quickLinks = [
+  {
+    label: "Post a gig opportunity",
+    icon: "CalendarPlus" as const,
+    href: "/gigs/post"
+  },
+  {
+    label: "Request avails from comedians",
+    icon: "CalendarSearch" as const,
+    href: "/dashboard/availability"
+  },
+  {
+    label: "Share production resources",
+    icon: "HardHat" as const,
+    href: "/dashboard/resources"
+  }
+];
+
+const profileHighlights = [
+  {
+    title: "Comedian profiles",
+    description:
+      "Keep avails, tech needs, reel, credits, and routing in one place so promoters can book without guesswork.",
+    icon: "Mic2" as const,
+    href: "/comedians"
+  },
+  {
+    title: "Venue profiles",
+    description:
+      "Publish room specs, payout models, load-in instructions, and contract templates to streamline every show night.",
+    icon: "Building2" as const,
+    href: "/venues"
+  }
+];
+
+const operationsNotes = [
+  {
+    title: "Background checks & verification",
+    description:
+      "Every promoter and venue is reviewed before posting so comics can share sensitive routing info with confidence.",
     icon: "ShieldCheck" as const
   },
   {
-    title: "Effortless booking",
-    description: "Centralized calendars, reminders, and contracts make coordination painless.",
-    icon: "CalendarCheck" as const
+    title: "Paperwork handled",
+    description:
+      "Generate deal memos, set payout schedules, and track W-9s right from the thread that kicked off the booking.",
+    icon: "FileSpreadsheet" as const
   },
   {
-    title: "Audience ready",
-    description: "Fans follow their favorites, reserve seats, and spread the word for you.",
-    icon: "Megaphone" as const
+    title: "Stay in sync",
+    description:
+      "Thread activity feeds directly into calendars, reminders, and group chats for your production team.",
+    icon: "BellRing" as const
   }
-];
-
-const workflow = [
-  {
-    title: "Share your vibe",
-    description: "Set your availability, drop a reel, and let the algorithm surface perfect matches.",
-    icon: "Mic2" as const
-  },
-  {
-    title: "Collaborate in one place",
-    description: "Chat, review offers, and confirm logistics without digging through inboxes.",
-    icon: "Sparkles" as const
-  },
-  {
-    title: "Showtime insights",
-    description: "Post-show dashboards reveal audience feedback, payouts, and future leads.",
-    icon: "Ticket" as const
-  }
-];
-
-const stats = [
-  { label: "Active comedians", value: "2.5k+" },
-  { label: "Verified hosts", value: "600+" },
-  { label: "Monthly gigs", value: "1,200" }
-];
-
-const heroHighlights = [
-  { label: "Verified promoters", icon: "ShieldCheck" as const },
-  { label: "Map-based search", icon: "Map" as const },
-  { label: "Community chat", icon: "ChatsCircle" as const, set: "phosphor" as const }
 ];
 
 export default function LandingPage() {
   return (
-    <section className="space-y-16 pb-12">
-      <div className="relative overflow-hidden rounded-4xl border border-white/40 bg-white/80 shadow-2xl shadow-slate-900/10 backdrop-blur-xl">
-        <HeroBackground pattern="topography" />
-        <div className="grid gap-12 p-10 lg:grid-cols-[1.1fr_0.9fr] lg:items-center lg:p-16">
-          <div className="space-y-9">
-            <div className="space-y-3">
-              <Badge className="bg-brand/10 text-brand">All-in-one comedy network</Badge>
-              <h1 className="text-4xl font-semibold text-slate-900 sm:text-5xl md:text-6xl">
-                Where comedy careers grow together.
-              </h1>
-              <p className="max-w-xl text-lg text-slate-600">
-                the-funny connects comedians, promoters, venues, and fans with a shared workflow that keeps every show on track from first pitch to encore.
-              </p>
-            </div>
-            <div className="flex flex-wrap items-center gap-4">
-              <Button asChild size="lg" className="gap-2 text-base">
-                <Link href="/gigs">
-                  Browse gigs <Icon name="ArrowRight" className="h-4 w-4" />
+    <section className="space-y-10 pb-16">
+      <Card className="border border-slate-200 bg-white shadow-sm">
+        <CardHeader className="space-y-4">
+          <Badge variant="outline" className="w-fit border-brand/30 text-brand">
+            Working comedy bulletin
+          </Badge>
+          <CardTitle className="text-3xl font-semibold text-slate-900 sm:text-4xl">
+            the-funny workboard
+          </CardTitle>
+          <p className="max-w-2xl text-base text-slate-600">
+            Built for comedians, promoters, and venues to coordinate shows, swap resources, and keep the run-of-show tight.
+            No fan features—just the tools the industry relies on to make nights happen.
+          </p>
+        </CardHeader>
+        <CardContent className="space-y-8">
+          <div className="flex flex-wrap gap-3">
+            <Button asChild size="lg" className="gap-2 text-base">
+              <Link href="/dashboard">
+                Enter message board
+                <Icon name="ArrowRight" className="h-4 w-4" />
+              </Link>
+            </Button>
+            <Button asChild size="lg" variant="outline" className="gap-2 text-base text-brand">
+              <Link href="/gigs/post">
+                Post an opportunity
+                <Icon name="Plus" className="h-4 w-4" />
+              </Link>
+            </Button>
+          </div>
+          <div className="grid gap-4 md:grid-cols-3">
+            {primaryActions.map((action) => (
+              <div key={action.label} className="rounded-2xl border border-dashed border-slate-200 bg-slate-50/60 p-4">
+                <p className="text-sm font-semibold text-slate-800">{action.label}</p>
+                <p className="mt-2 text-sm text-slate-600">{action.description}</p>
+                <Button asChild variant="link" className="mt-3 h-auto p-0 text-sm text-brand">
+                  <Link href={action.href}>Create profile</Link>
+                </Button>
+              </div>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+
+      <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_320px]">
+        <Card className="border border-slate-200 bg-white shadow-sm">
+          <CardHeader className="space-y-2">
+            <Badge variant="outline" className="w-fit border-slate-200 text-slate-600">
+              Live threads
+            </Badge>
+            <CardTitle className="text-2xl text-slate-900">Today on the board</CardTitle>
+            <p className="text-sm text-slate-600">
+              Threads stay focused on actionable details—drop avails, negotiate terms, and lock the lineup without leaving the
+              conversation.
+            </p>
+          </CardHeader>
+          <CardContent className="space-y-6">
+            {boardThreads.map((thread) => (
+              <article key={thread.title} className="space-y-3 rounded-2xl border border-slate-200/80 p-4">
+                <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                  <h3 className="text-lg font-semibold text-slate-900">{thread.title}</h3>
+                  <span className="text-xs text-slate-500">Updated {thread.updated}</span>
+                </div>
+                <p className="text-sm text-slate-600">{thread.excerpt}</p>
+                <div className="flex flex-wrap items-center gap-3 text-xs text-slate-500">
+                  <div className="flex items-center gap-1 text-slate-600">
+                    <Icon name="MessageCircle" className="h-3.5 w-3.5" />
+                    {thread.replies} replies
+                  </div>
+                  {thread.tags.map((tag) => (
+                    <span key={tag} className="rounded-full bg-slate-100 px-3 py-1 text-slate-600">
+                      #{tag}
+                    </span>
+                  ))}
+                  <Button asChild variant="ghost" size="sm" className="ml-auto h-7 px-3 text-xs">
+                    <Link href="/dashboard">Open thread</Link>
+                  </Button>
+                </div>
+              </article>
+            ))}
+          </CardContent>
+        </Card>
+        <Card className="border border-slate-200 bg-slate-50 shadow-inner">
+          <CardHeader className="space-y-2">
+            <CardTitle className="text-lg text-slate-800">Quick actions</CardTitle>
+            <p className="text-sm text-slate-600">Keep the workflow moving with one-click tools.</p>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {quickLinks.map((link) => (
+              <Button
+                key={link.label}
+                asChild
+                variant="ghost"
+                className="w-full justify-start gap-3 border border-slate-200 bg-white text-left text-sm font-medium text-slate-700 hover:border-brand/40"
+              >
+                <Link href={link.href}>
+                  <Icon name={link.icon} className="h-4 w-4 text-brand" />
+                  {link.label}
                 </Link>
               </Button>
-              <Button asChild size="lg" variant="outline" className="border-brand/30 text-base text-brand">
-                <Link href="/auth/sign-up">Create an account</Link>
-              </Button>
-              <p className="text-sm text-slate-500">
-                Free to join • Personalized matches • Trusted by industry leaders
+            ))}
+            <div className="rounded-2xl border border-dashed border-slate-300 bg-white p-4 text-sm text-slate-600">
+              <p className="font-semibold text-slate-800">Need something else?</p>
+              <p className="mt-1">
+                Start a &quot;Help wanted&quot; thread and tag the city or tour leg you&apos;re working on. The community can jump in with
+                resources fast.
               </p>
             </div>
-            <div className="flex flex-wrap items-center gap-4 text-sm text-slate-600">
-              {heroHighlights.map((item) => (
-                <span key={item.label} className="inline-flex items-center gap-2 rounded-full bg-white/80 px-4 py-2 text-slate-700 shadow-sm">
-                  <Icon name={item.icon} set={item.set ?? "lucide"} className="h-4 w-4 text-brand" />
-                  {item.label}
-                </span>
-              ))}
-            </div>
-            <div className="grid gap-6 sm:grid-cols-3">
-              {stats.map((stat) => (
-                <div key={stat.label} className="rounded-2xl border border-white/60 bg-white/90 p-4 shadow-sm">
-                  <p className="text-2xl font-semibold text-brand">{stat.value}</p>
-                  <p className="text-sm text-slate-500">{stat.label}</p>
-                </div>
-              ))}
-            </div>
-          </div>
-          <div className="flex flex-col gap-6">
-            <div className="relative overflow-hidden rounded-3xl border border-slate-200/60 bg-white/60 shadow-xl">
-              <Image
-                src="/assets/hero/stage-lights.svg"
-                alt="Stylized spotlights shining on a comedy stage"
-                width={1200}
-                height={900}
-                className="h-full w-full object-cover"
-                priority
-              />
-            </div>
-            <div className="relative overflow-hidden rounded-3xl bg-gradient-to-br from-brand to-brand-dark p-8 text-slate-100 shadow-xl">
-              <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(255,255,255,0.18),_transparent_60%)]" />
-              <div className="relative space-y-6">
-                <div className="inline-flex items-center gap-2 rounded-full bg-white/15 px-4 py-1 text-xs uppercase tracking-wide">
-                  <Icon name="Star" set="phosphor" className="h-3.5 w-3.5 text-amber-200" /> Trusted talent pipeline
-                </div>
-                <p className="text-2xl font-semibold leading-snug">
-                  “the-funny handles everything from discovery to payout so I can focus on the set.”
-                </p>
-                <div className="space-y-1 text-sm text-slate-200">
-                  <p>Ally Rivera</p>
-                  <p className="text-xs text-slate-300">Promoter @ Skyline Rooms</p>
-                </div>
-                <div className="grid gap-3 sm:grid-cols-2">
-                  {testimonialHighlights.map((feature) => (
-                    <div key={feature.title} className="rounded-2xl border border-white/20 bg-white/10 p-4">
-                      <Icon name={feature.icon} className="mb-3 h-6 w-6 text-amber-200" />
-                      <p className="text-sm font-semibold">{feature.title}</p>
-                      <p className="mt-1 text-xs text-slate-200/80">{feature.description}</p>
-                    </div>
-                  ))}
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
+          </CardContent>
+        </Card>
       </div>
 
       <div className="grid gap-6 md:grid-cols-2">
-        {roles.map((role) => (
-          <Card
-            key={role.title}
-            className="flex flex-col justify-between border-transparent bg-white/90 shadow-lg shadow-slate-900/5 transition hover:-translate-y-1 hover:border-brand/30 hover:shadow-xl"
-          >
-            <CardHeader>
-              <CardTitle className="flex items-center justify-between text-xl">
-                {role.title}
-                <Icon name="ArrowRight" className="h-5 w-5 text-brand/60" />
-              </CardTitle>
+        {profileHighlights.map((profile) => (
+          <Card key={profile.title} className="border border-slate-200 bg-white shadow-sm">
+            <CardHeader className="flex flex-row items-start gap-3">
+              <span className="flex h-10 w-10 items-center justify-center rounded-full bg-brand/10 text-brand">
+                <Icon name={profile.icon} className="h-5 w-5" />
+              </span>
+              <div>
+                <CardTitle className="text-xl text-slate-900">{profile.title}</CardTitle>
+                <p className="mt-1 text-sm text-slate-600">{profile.description}</p>
+              </div>
             </CardHeader>
-            <CardContent className="space-y-5 text-sm text-slate-600">
-              <p>{role.description}</p>
-              <Button asChild variant="outline" className="self-start border-brand/40 text-brand">
-                <Link href={role.href}>Get started</Link>
+            <CardContent>
+              <Button asChild variant="outline" className="border-brand/40 text-brand">
+                <Link href={profile.href}>Explore profiles</Link>
               </Button>
             </CardContent>
           </Card>
         ))}
       </div>
 
-      <div className="grid gap-6 lg:grid-cols-[1.2fr_1fr]">
-        <Card className="border-transparent bg-white/90 shadow-lg shadow-slate-900/5">
-          <CardHeader className="space-y-2">
-            <Badge variant="outline" className="w-fit border-brand/30 text-brand">
-              How it works
-            </Badge>
-            <CardTitle className="text-2xl text-slate-900">Simple workflow from inquiry to encore</CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-6">
-            {workflow.map((step, index) => (
-              <div key={step.title} className="flex gap-4">
-                <div className="flex h-10 w-10 items-center justify-center rounded-full border border-brand/30 bg-brand/10 text-brand">
-                  {index + 1}
-                </div>
-                <div className="space-y-1">
-                  <p className="flex items-center gap-2 text-sm font-semibold text-slate-900">
-                    <Icon name={step.icon} className="h-4 w-4 text-brand" /> {step.title}
-                  </p>
-                  <p className="text-sm text-slate-600">{step.description}</p>
-                </div>
+      <Card className="border border-slate-200 bg-white shadow-sm">
+        <CardHeader className="space-y-2">
+          <Badge variant="outline" className="w-fit border-slate-200 text-slate-600">
+            Operations essentials
+          </Badge>
+          <CardTitle className="text-2xl text-slate-900">Why working comics stay here</CardTitle>
+          <p className="text-sm text-slate-600">
+            Every feature protects the people doing the work—no fan chatter, just logistics, accountability, and faster payouts.
+          </p>
+        </CardHeader>
+        <CardContent className="grid gap-4 md:grid-cols-3">
+          {operationsNotes.map((note) => (
+            <div key={note.title} className="space-y-2 rounded-2xl border border-slate-200/80 p-4">
+              <div className="flex items-center gap-2 text-slate-700">
+                <Icon name={note.icon} className="h-4 w-4 text-brand" />
+                <p className="text-sm font-semibold">{note.title}</p>
               </div>
-            ))}
-          </CardContent>
-        </Card>
-
-        <Card className="border-transparent bg-gradient-to-br from-white/95 via-white/80 to-white/60 shadow-lg shadow-slate-900/5">
-          <CardContent className="flex h-full flex-col justify-between space-y-6">
-            <div className="space-y-3">
-              <Badge variant="outline" className="w-fit border-amber-300/50 bg-amber-50 text-amber-700">
-                Spotlight
-              </Badge>
-              <p className="text-lg font-semibold text-slate-900">
-                “Our rooms stay booked weeks ahead because comedians trust the-funny’s verification and fans love the smooth ticketing experience.”
-              </p>
+              <p className="text-sm text-slate-600">{note.description}</p>
             </div>
-            <div className="flex items-center gap-3">
-              <div className="flex h-12 w-12 items-center justify-center rounded-full bg-brand/10 text-brand">
-                <Icon name="Users" className="h-6 w-6" />
-              </div>
-              <div>
-                <p className="text-sm font-semibold text-slate-900">Marquee Collective</p>
-                <p className="text-xs text-slate-500">Venue network partner</p>
-              </div>
-            </div>
-          </CardContent>
-        </Card>
-      </div>
-
-      <Card className="border-brand/20 bg-white/90 shadow-xl shadow-slate-900/10">
-        <CardContent className="flex flex-col items-center justify-between gap-6 py-8 text-center md:flex-row md:text-left">
-          <div className="flex items-center gap-4 text-slate-700">
-            <div className="flex h-10 w-10 items-center justify-center rounded-full bg-brand/10 text-brand">
-              <Icon name="Users" className="h-5 w-5" />
-            </div>
-            <div className="space-y-1">
-              <h2 className="text-2xl font-semibold text-slate-900">Ready to take the mic?</h2>
-              <p className="text-sm text-slate-600">
-                Add maps, ticketing, payouts, and deeper analytics whenever you are ready to level up.
-              </p>
-            </div>
-          </div>
-          <div className="flex flex-wrap justify-center gap-3">
-            <Button asChild>
-              <Link href="/auth/sign-in">Sign in</Link>
-            </Button>
-            <Button asChild variant="outline" className="border-brand/40 text-brand">
-              <Link href="/post-gig">Post a gig</Link>
-            </Button>
-          </div>
+          ))}
         </CardContent>
       </Card>
     </section>


### PR DESCRIPTION
## Summary
- replace marketing-heavy hero with a streamlined workboard overview highlighting professional actions
- surface live thread previews, quick workflow links, and dedicated comedian/venue profile callouts for industry use only
- document verification and operations safeguards to reinforce the board-style focus for working comics

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68de8b2be4ec8323a6d5f35b7d73837e