### PR TITLE
Add messaging workflow with offers, bookings, and reviews

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Production-ready starter for a stand-up comedy marketplace built with Next.js 14
 - Verification request management with document uploads and admin approvals
 - Tailwind CSS + shadcn-inspired UI primitives for rapid extension
 - REST API endpoints secured with rate limiting and role checks
+- Messaging center with offer/quote workflow, payout-protected bookings, and reporting tools
 - Vitest unit tests
 - Dockerfile and docker-compose for local development
 

--- a/app/api/bookings/[id]/pay/route.ts
+++ b/app/api/bookings/[id]/pay/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import {
+  createMessage,
+  getBookingById,
+  getOfferById,
+  updateBooking
+} from "@/lib/dataStore";
+
+export async function POST(_: Request, { params }: { params: { id: string } }) {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const booking = await getBookingById(params.id);
+  if (!booking) {
+    return NextResponse.json({ error: "Booking not found" }, { status: 404 });
+  }
+
+  if (![booking.comedianId, booking.promoterId].includes(session.user.id)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const paymentIntentId = `pi_mock_${booking.id}`;
+  const updated = await updateBooking(booking.id, { status: "PAID", paymentIntentId });
+
+  const offer = await getOfferById(booking.offerId);
+  if (offer) {
+    await createMessage({
+      threadId: offer.threadId,
+      senderId: session.user.id,
+      kind: "SYSTEM",
+      body: "Payment confirmed. You're protected under platform payout coverage."
+    });
+  }
+
+  return NextResponse.json({ booking: updated, paymentIntentId });
+}

--- a/app/api/offers/[id]/accept/route.ts
+++ b/app/api/offers/[id]/accept/route.ts
@@ -1,0 +1,63 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import {
+  createBooking,
+  createMessage,
+  getOfferById,
+  getThreadById,
+  getUserById,
+  markThreadState,
+  updateOfferStatus
+} from "@/lib/dataStore";
+
+export async function POST(_: Request, { params }: { params: { id: string } }) {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const offer = await getOfferById(params.id);
+  if (!offer) {
+    return NextResponse.json({ error: "Offer not found" }, { status: 404 });
+  }
+
+  if (offer.status !== "PENDING") {
+    return NextResponse.json({ error: "Offer already resolved" }, { status: 400 });
+  }
+
+  const thread = await getThreadById(offer.threadId);
+  if (!thread) {
+    return NextResponse.json({ error: "Thread not found" }, { status: 404 });
+  }
+
+  if (!thread.participantIds.includes(session.user.id) || session.user.id === offer.fromUserId) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const fromUser = await getUserById(offer.fromUserId);
+  const acceptingUser = await getUserById(session.user.id);
+  if (!fromUser || !acceptingUser) {
+    return NextResponse.json({ error: "Participants missing" }, { status: 400 });
+  }
+
+  const promoterId = fromUser.role === "COMEDIAN" ? acceptingUser.id : fromUser.id;
+  const comedianId = fromUser.role === "COMEDIAN" ? fromUser.id : acceptingUser.id;
+
+  await updateOfferStatus(offer.id, "ACCEPTED");
+  const booking = await createBooking({
+    gigId: thread.gigId,
+    comedianId,
+    promoterId,
+    offerId: offer.id
+  });
+
+  await markThreadState(thread.id, "BOOKED");
+  await createMessage({
+    threadId: thread.id,
+    senderId: session.user.id,
+    kind: "SYSTEM",
+    body: `Offer accepted. Booking created: ${booking.id}`
+  });
+
+  return NextResponse.json({ booking }, { status: 201 });
+}

--- a/app/api/offers/[id]/decline/route.ts
+++ b/app/api/offers/[id]/decline/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import {
+  createMessage,
+  getOfferById,
+  getThreadById,
+  updateOfferStatus
+} from "@/lib/dataStore";
+
+export async function POST(_: Request, { params }: { params: { id: string } }) {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const offer = await getOfferById(params.id);
+  if (!offer) {
+    return NextResponse.json({ error: "Offer not found" }, { status: 404 });
+  }
+
+  if (offer.status !== "PENDING") {
+    return NextResponse.json({ error: "Offer already resolved" }, { status: 400 });
+  }
+
+  const thread = await getThreadById(offer.threadId);
+  if (!thread || !thread.participantIds.includes(session.user.id) || session.user.id === offer.fromUserId) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  await updateOfferStatus(offer.id, "DECLINED");
+  await createMessage({
+    threadId: offer.threadId,
+    senderId: session.user.id,
+    kind: "SYSTEM",
+    body: "Offer declined."
+  });
+
+  return NextResponse.json({ ok: true });
+}

--- a/app/api/offers/[id]/withdraw/route.ts
+++ b/app/api/offers/[id]/withdraw/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import {
+  createMessage,
+  getOfferById,
+  updateOfferStatus
+} from "@/lib/dataStore";
+
+export async function POST(_: Request, { params }: { params: { id: string } }) {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const offer = await getOfferById(params.id);
+  if (!offer) {
+    return NextResponse.json({ error: "Offer not found" }, { status: 404 });
+  }
+
+  if (offer.fromUserId !== session.user.id) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  if (offer.status !== "PENDING") {
+    return NextResponse.json({ error: "Offer already resolved" }, { status: 400 });
+  }
+
+  await updateOfferStatus(offer.id, "WITHDRAWN");
+  await createMessage({
+    threadId: offer.threadId,
+    senderId: session.user.id,
+    kind: "SYSTEM",
+    body: "Offer withdrawn by sender."
+  });
+
+  return NextResponse.json({ ok: true });
+}

--- a/app/api/report/route.ts
+++ b/app/api/report/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { auth } from "@/lib/auth";
+import { createReport } from "@/lib/dataStore";
+
+const reportSchema = z.object({
+  targetType: z.enum(["USER", "THREAD", "GIG"]),
+  targetId: z.string().min(1),
+  reason: z.string().min(3),
+  details: z.string().optional()
+});
+
+export async function POST(request: Request) {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const parsed = reportSchema.safeParse(await request.json());
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 });
+  }
+
+  const report = await createReport({
+    reporterId: session.user.id,
+    targetType: parsed.data.targetType,
+    targetId: parsed.data.targetId,
+    reason: parsed.data.reason,
+    details: parsed.data.details ?? null
+  });
+
+  return NextResponse.json({ report }, { status: 201 });
+}

--- a/app/api/reviews/route.ts
+++ b/app/api/reviews/route.ts
@@ -1,0 +1,55 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { auth } from "@/lib/auth";
+import {
+  createConversationReview,
+  getBookingById,
+  listConversationReviewsForBooking
+} from "@/lib/dataStore";
+
+const reviewSchema = z.object({
+  bookingId: z.string().min(1),
+  rating: z.number().int().min(1).max(5),
+  body: z.string().min(10)
+});
+
+export async function POST(request: Request) {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const parsed = reviewSchema.safeParse(await request.json());
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 });
+  }
+
+  const booking = await getBookingById(parsed.data.bookingId);
+  if (!booking) {
+    return NextResponse.json({ error: "Booking not found" }, { status: 404 });
+  }
+
+  if (![booking.comedianId, booking.promoterId].includes(session.user.id)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  if (!["PAID", "COMPLETED"].includes(booking.status)) {
+    return NextResponse.json({ error: "Reviews available after the show" }, { status: 400 });
+  }
+
+  const existing = await listConversationReviewsForBooking(booking.id);
+  if (existing.some((review) => review.fromUserId === session.user.id)) {
+    return NextResponse.json({ error: "Review already submitted" }, { status: 409 });
+  }
+
+  const toUserId = session.user.id === booking.comedianId ? booking.promoterId : booking.comedianId;
+  const review = await createConversationReview({
+    bookingId: booking.id,
+    fromUserId: session.user.id,
+    toUserId,
+    rating: parsed.data.rating,
+    body: parsed.data.body
+  });
+
+  return NextResponse.json({ review }, { status: 201 });
+}

--- a/app/api/threads/[id]/messages/route.ts
+++ b/app/api/threads/[id]/messages/route.ts
@@ -1,0 +1,107 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { auth } from "@/lib/auth";
+import {
+  createMessage,
+  createOffer,
+  getThreadById,
+  listMessagesForThread,
+  listOffersForThread,
+  markThreadState
+} from "@/lib/dataStore";
+import { rateLimit } from "@/lib/rateLimit";
+
+const messageSchema = z.discriminatedUnion("kind", [
+  z.object({
+    kind: z.literal("TEXT"),
+    body: z.string().min(1),
+    fileUrl: z.string().url().optional()
+  }),
+  z.object({
+    kind: z.literal("FILE"),
+    body: z.string().optional(),
+    fileUrl: z.string().url()
+  }),
+  z.object({
+    kind: z.literal("OFFER"),
+    body: z.string().optional(),
+    offer: z.object({
+      amount: z.number().int().min(1),
+      currency: z.string().default("USD"),
+      terms: z.string().min(5),
+      eventDate: z.string().datetime(),
+      expiresAt: z.string().datetime().optional()
+    })
+  })
+]);
+
+export async function GET(_: Request, { params }: { params: { id: string } }) {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const thread = await getThreadById(params.id);
+  if (!thread || !thread.participantIds.includes(session.user.id)) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  const [messages, offers] = await Promise.all([
+    listMessagesForThread(thread.id),
+    listOffersForThread(thread.id)
+  ]);
+
+  return NextResponse.json({ thread, messages, offers });
+}
+
+export async function POST(request: Request, { params }: { params: { id: string } }) {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  if (!rateLimit(`threads:message:${session.user.id}`)) {
+    return NextResponse.json({ error: "Too many requests" }, { status: 429 });
+  }
+
+  const thread = await getThreadById(params.id);
+  if (!thread) {
+    return NextResponse.json({ error: "Thread not found" }, { status: 404 });
+  }
+
+  if (!thread.participantIds.includes(session.user.id)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const json = await request.json();
+  const parsed = messageSchema.safeParse(json);
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 });
+  }
+
+  let offerId: string | null = null;
+  if (parsed.data.kind === "OFFER") {
+    const offer = await createOffer({
+      threadId: thread.id,
+      fromUserId: session.user.id,
+      amount: parsed.data.offer.amount,
+      currency: parsed.data.offer.currency,
+      terms: parsed.data.offer.terms,
+      eventDate: new Date(parsed.data.offer.eventDate),
+      expiresAt: parsed.data.offer.expiresAt ? new Date(parsed.data.offer.expiresAt) : null
+    });
+    offerId = offer.id;
+    await markThreadState(thread.id, "QUOTE");
+  }
+
+  const message = await createMessage({
+    threadId: thread.id,
+    senderId: session.user.id,
+    kind: parsed.data.kind,
+    body: "body" in parsed.data ? parsed.data.body ?? null : null,
+    fileUrl: "fileUrl" in parsed.data ? parsed.data.fileUrl ?? null : null,
+    offerId
+  });
+
+  return NextResponse.json({ message, offerId }, { status: 201 });
+}

--- a/app/api/threads/route.ts
+++ b/app/api/threads/route.ts
@@ -1,0 +1,81 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { auth } from "@/lib/auth";
+import {
+  createMessage,
+  createThread,
+  getGigById,
+  getUserById,
+  listMessagesForThread,
+  listThreadsForUser
+} from "@/lib/dataStore";
+import { rateLimit } from "@/lib/rateLimit";
+
+const createThreadSchema = z.object({
+  gigId: z.string().min(1),
+  participantIds: z.array(z.string().min(1)).min(1),
+  initialMessage: z.string().min(1).optional()
+});
+
+export async function GET() {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const threads = await listThreadsForUser(session.user.id);
+  const hydrated = await Promise.all(
+    threads.map(async (thread) => {
+      const gig = await getGigById(thread.gigId);
+      const participants = await Promise.all(thread.participantIds.map((id) => getUserById(id)));
+      const messages = await listMessagesForThread(thread.id);
+      return {
+        thread,
+        gig,
+        participants: participants.filter((value): value is NonNullable<typeof value> => Boolean(value)),
+        lastMessage: messages.length ? messages[messages.length - 1] : null
+      };
+    })
+  );
+
+  return NextResponse.json({ threads: hydrated });
+}
+
+export async function POST(request: Request) {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  if (!rateLimit(`threads:create:${session.user.id}`)) {
+    return NextResponse.json({ error: "Too many requests" }, { status: 429 });
+  }
+
+  const json = await request.json();
+  const parsed = createThreadSchema.safeParse(json);
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 });
+  }
+
+  const gig = await getGigById(parsed.data.gigId);
+  if (!gig) {
+    return NextResponse.json({ error: "Gig not found" }, { status: 404 });
+  }
+
+  const thread = await createThread({
+    gigId: parsed.data.gigId,
+    createdById: session.user.id,
+    participantIds: parsed.data.participantIds
+  });
+
+  if (parsed.data.initialMessage) {
+    await createMessage({
+      threadId: thread.id,
+      senderId: session.user.id,
+      kind: "TEXT",
+      body: parsed.data.initialMessage
+    });
+  }
+
+  return NextResponse.json({ thread }, { status: 201 });
+}

--- a/app/api/users/[id]/profile/route.ts
+++ b/app/api/users/[id]/profile/route.ts
@@ -1,0 +1,76 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import {
+  getComedianProfile,
+  getPromoterProfile,
+  getUserById,
+  getVenueProfile,
+  listConversationReviewsForUser
+} from "@/lib/dataStore";
+
+function computeProfileStrength(values: Array<string | number | null | undefined>) {
+  if (!values.length) return 0;
+  const completed = values.filter((value) => value !== null && value !== undefined && `${value}`.trim().length > 0).length;
+  return Math.round((completed / values.length) * 100);
+}
+
+export async function GET(_: Request, { params }: { params: { id: string } }) {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  if (session.user.id !== params.id && session.user.role !== "ADMIN") {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const user = await getUserById(params.id);
+  if (!user) {
+    return NextResponse.json({ error: "User not found" }, { status: 404 });
+  }
+
+  const [comedian, promoter, venue, reviews] = await Promise.all([
+    getComedianProfile(user.id),
+    getPromoterProfile(user.id),
+    getVenueProfile(user.id),
+    listConversationReviewsForUser(user.id)
+  ]);
+
+  const ratingAvg = reviews.length ? reviews.reduce((total, review) => total + review.rating, 0) / reviews.length : 0;
+  const profileStrength = computeProfileStrength(
+    user.role === "COMEDIAN"
+      ? [
+          comedian?.stageName,
+          comedian?.bio,
+          comedian?.website,
+          comedian?.reelUrl,
+          comedian?.instagram,
+          comedian?.travelRadiusMiles,
+          comedian?.homeCity,
+          comedian?.homeState
+        ]
+      : user.role === "PROMOTER"
+      ? [promoter?.organization, promoter?.contactName, promoter?.website, promoter?.phone]
+      : user.role === "VENUE"
+      ? [venue?.venueName, venue?.address1, venue?.city, venue?.state, venue?.capacity]
+      : []
+  );
+
+  const badges: string[] = [];
+  if (reviews.length >= 10 && ratingAvg >= 4.7) {
+    badges.push("Top Rated");
+  }
+  if (user.role === "VENUE" && venue?.verificationStatus === "APPROVED") {
+    badges.push("Venue Verified");
+  }
+
+  return NextResponse.json({
+    user,
+    profile: comedian ?? promoter ?? venue ?? null,
+    reviews,
+    ratingAvg,
+    ratingCount: reviews.length,
+    profileStrength,
+    badges
+  });
+}

--- a/app/inbox/page.tsx
+++ b/app/inbox/page.tsx
@@ -1,0 +1,156 @@
+import Link from "next/link";
+import { auth } from "@/lib/auth";
+import {
+  getGigById,
+  getUserById,
+  listMessagesForThread,
+  listOffersForThread,
+  listThreadsForUser
+} from "@/lib/dataStore";
+import { SAFETY_TIPS } from "@/lib/config/commerce";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+export default async function InboxPage() {
+  const session = await auth();
+  if (!session?.user) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Sign in to view messages</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3 text-sm text-slate-600">
+          <p>You need an account to access the messaging center.</p>
+          <Link className="text-brand" href="/auth/sign-in">
+            Go to sign in
+          </Link>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const threads = await listThreadsForUser(session.user.id);
+  if (threads.length === 0) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Your inbox is quiet</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3 text-sm text-slate-600">
+          <p>No conversations yet. Start by applying to a gig or messaging a comedian.</p>
+          <div>
+            <h2 className="text-xs uppercase tracking-wide text-slate-500">Safety tips</h2>
+            <ul className="mt-2 list-disc space-y-1 pl-5">
+              {SAFETY_TIPS.map((tip) => (
+                <li key={tip}>{tip}</li>
+              ))}
+            </ul>
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const hydrated = await Promise.all(
+    threads.map(async (thread) => {
+      const gig = await getGigById(thread.gigId);
+      const participants = await Promise.all(thread.participantIds.map((id) => getUserById(id)));
+      const messages = await listMessagesForThread(thread.id);
+      const offers = await listOffersForThread(thread.id);
+      return {
+        thread,
+        gig,
+        participants: participants.filter((value): value is NonNullable<typeof value> => Boolean(value)),
+        messages,
+        offers
+      };
+    })
+  );
+
+  return (
+    <div className="grid gap-6 lg:grid-cols-[300px,1fr]">
+      <Card className="h-fit">
+        <CardHeader>
+          <CardTitle>Threads</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4 text-sm text-slate-600">
+          {hydrated.map(({ thread, gig }) => (
+            <div key={thread.id} className="rounded-md border border-slate-200 p-3">
+              <div className="flex items-center justify-between">
+                <span className="font-medium">{gig?.title ?? "Private gig"}</span>
+                <Badge variant="outline">{thread.state}</Badge>
+              </div>
+              <p className="text-xs text-slate-500">Last message {thread.lastMessageAt.toLocaleString()}</p>
+            </div>
+          ))}
+        </CardContent>
+      </Card>
+
+      <div className="space-y-6">
+        {hydrated.map(({ thread, gig, participants, messages, offers }) => (
+          <Card key={thread.id}>
+            <CardHeader>
+              <CardTitle className="flex items-center justify-between gap-2 text-base">
+                <span>{gig?.title ?? "Gig conversation"}</span>
+                <Badge variant="secondary">{participants.length} participants</Badge>
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4 text-sm">
+              <div className="rounded-md bg-amber-50 p-3 text-xs text-amber-900">
+                <strong className="block text-amber-900">Payment protection</strong>
+                Keep communication on The Funny to qualify for payout coverage and dispute support.
+              </div>
+
+              <div className="space-y-3">
+                {messages.map((message) => {
+                  const sender = participants.find((user) => user.id === message.senderId);
+                  const offer = offers.find((item) => item.id === message.offerId);
+                  return (
+                    <div key={message.id} className="rounded-md border border-slate-200 p-3">
+                      <div className="flex items-center justify-between">
+                        <span className="font-medium">{sender?.name ?? "System"}</span>
+                        <span className="text-xs text-slate-500">{message.createdAt.toLocaleString()}</span>
+                      </div>
+                      {message.body && <p className="mt-2 whitespace-pre-line text-slate-700">{message.body}</p>}
+                      {offer && (
+                        <div className="mt-3 rounded-md border border-brand/30 bg-brand/5 p-3 text-sm">
+                          <div className="flex items-center justify-between">
+                            <span className="font-semibold">Offer</span>
+                            <Badge variant="outline">{offer.status}</Badge>
+                          </div>
+                          <dl className="mt-2 space-y-1 text-xs text-slate-600">
+                            <div className="flex items-center justify-between">
+                              <dt>Amount</dt>
+                              <dd>${(offer.amount / 100).toFixed(2)} {offer.currency}</dd>
+                            </div>
+                            <div className="flex items-center justify-between">
+                              <dt>Event date</dt>
+                              <dd>{offer.eventDate.toLocaleString()}</dd>
+                            </div>
+                            <div>
+                              <dt className="font-medium text-slate-700">Terms</dt>
+                              <dd>{offer.terms}</dd>
+                            </div>
+                          </dl>
+                        </div>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+
+              <div>
+                <h3 className="text-xs uppercase tracking-wide text-slate-500">Safety tips</h3>
+                <ul className="mt-2 list-disc space-y-1 pl-5 text-xs text-slate-600">
+                  {SAFETY_TIPS.map((tip) => (
+                    <li key={tip}>{tip}</li>
+                  ))}
+                </ul>
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/data/database.json
+++ b/data/database.json
@@ -297,5 +297,124 @@
       "createdAt": "2024-03-21T12:00:00.000Z",
       "updatedAt": "2024-03-21T12:00:00.000Z"
     }
-  ]
+  ],
+  "threads": [
+    {
+      "id": "thread-1",
+      "gigId": "gig-1",
+      "createdById": "user-promoter",
+      "participantIds": ["user-promoter", "user-comic1"],
+      "state": "QUOTE",
+      "lastMessageAt": "2024-03-25T18:00:00.000Z",
+      "createdAt": "2024-03-24T16:00:00.000Z",
+      "updatedAt": "2024-03-25T18:00:00.000Z"
+    }
+  ],
+  "messages": [
+    {
+      "id": "msg-1",
+      "threadId": "thread-1",
+      "senderId": "user-promoter",
+      "kind": "TEXT",
+      "body": "Hi Casey! Loved your reel and think you'd be perfect for our showcase.",
+      "fileUrl": null,
+      "offerId": null,
+      "createdAt": "2024-03-24T16:05:00.000Z"
+    },
+    {
+      "id": "msg-2",
+      "threadId": "thread-1",
+      "senderId": "user-comic1",
+      "kind": "TEXT",
+      "body": "Thanks Polly! What's the format and payout?",
+      "fileUrl": null,
+      "offerId": null,
+      "createdAt": "2024-03-24T16:25:00.000Z"
+    },
+    {
+      "id": "msg-3",
+      "threadId": "thread-1",
+      "senderId": "user-promoter",
+      "kind": "OFFER",
+      "body": null,
+      "fileUrl": null,
+      "offerId": "offer-1",
+      "createdAt": "2024-03-24T17:00:00.000Z"
+    },
+    {
+      "id": "msg-4",
+      "threadId": "thread-1",
+      "senderId": "user-comic1",
+      "kind": "SYSTEM",
+      "body": "Offer accepted. Booking created: booking-1",
+      "fileUrl": null,
+      "offerId": null,
+      "createdAt": "2024-03-25T18:00:00.000Z"
+    }
+  ],
+  "offers": [
+    {
+      "id": "offer-1",
+      "threadId": "thread-1",
+      "fromUserId": "user-promoter",
+      "amount": 45000,
+      "currency": "USD",
+      "terms": "25-minute feature set, house provides sound and lights.",
+      "eventDate": "2024-04-15T20:00:00.000Z",
+      "expiresAt": "2024-03-31T23:59:59.000Z",
+      "status": "ACCEPTED",
+      "createdAt": "2024-03-24T17:00:00.000Z"
+    }
+  ],
+  "bookings": [
+    {
+      "id": "booking-1",
+      "gigId": "gig-1",
+      "comedianId": "user-comic1",
+      "promoterId": "user-promoter",
+      "offerId": "offer-1",
+      "status": "PAID",
+      "payoutProtection": true,
+      "cancellationPolicy": "STANDARD",
+      "paymentIntentId": "pi_mock_123",
+      "createdAt": "2024-03-25T18:00:00.000Z"
+    }
+  ],
+  "conversationReviews": [
+    {
+      "id": "review-1",
+      "bookingId": "booking-1",
+      "fromUserId": "user-comic1",
+      "toUserId": "user-promoter",
+      "rating": 5,
+      "body": "Clear communication and great crowd!",
+      "visible": true,
+      "createdAt": "2024-04-16T12:00:00.000Z"
+    },
+    {
+      "id": "review-2",
+      "bookingId": "booking-1",
+      "fromUserId": "user-promoter",
+      "toUserId": "user-comic1",
+      "rating": 5,
+      "body": "Casey crushed it and was super professional.",
+      "visible": true,
+      "createdAt": "2024-04-16T12:05:00.000Z"
+    }
+  ],
+  "availability": [
+    {
+      "id": "avail-1",
+      "userId": "user-comic1",
+      "date": "2024-04-15T00:00:00.000Z",
+      "status": "busy"
+    },
+    {
+      "id": "avail-2",
+      "userId": "user-comic1",
+      "date": "2024-04-16T00:00:00.000Z",
+      "status": "free"
+    }
+  ],
+  "reports": []
 }

--- a/lib/config/commerce.ts
+++ b/lib/config/commerce.ts
@@ -1,0 +1,16 @@
+export const FEES = {
+  bookingPercentFree: 5,
+  bookingPercentPro: 2.5
+} as const;
+
+export const CANCELLATION_POLICIES = {
+  FLEX: "Full refund up to 24 hours before the event.",
+  STANDARD: "50% refund available up to 72 hours before showtime.",
+  STRICT: "Non-refundable within 7 days of the event."
+} as const;
+
+export const SAFETY_TIPS = [
+  "Keep payment and communication on-platform for payout protection.",
+  "Double-check event logistics before confirming travel or expenses.",
+  "Report suspicious links, files, or off-platform payment requests."
+] as const;

--- a/lib/prismaEnums.ts
+++ b/lib/prismaEnums.ts
@@ -33,6 +33,47 @@ const fallbackApplicationStatus = {
   WITHDRAWN: "WITHDRAWN"
 } as const;
 
+const fallbackThreadState = {
+  INQUIRY: "INQUIRY",
+  QUOTE: "QUOTE",
+  BOOKED: "BOOKED",
+  COMPLETED: "COMPLETED"
+} as const;
+
+const fallbackMessageKind = {
+  TEXT: "TEXT",
+  FILE: "FILE",
+  OFFER: "OFFER",
+  SYSTEM: "SYSTEM"
+} as const;
+
+const fallbackOfferStatus = {
+  PENDING: "PENDING",
+  ACCEPTED: "ACCEPTED",
+  DECLINED: "DECLINED",
+  WITHDRAWN: "WITHDRAWN",
+  EXPIRED: "EXPIRED"
+} as const;
+
+const fallbackBookingStatus = {
+  PENDING: "PENDING",
+  PAID: "PAID",
+  COMPLETED: "COMPLETED",
+  CANCELLED: "CANCELLED"
+} as const;
+
+const fallbackCancellationPolicy = {
+  FLEX: "FLEX",
+  STANDARD: "STANDARD",
+  STRICT: "STRICT"
+} as const;
+
+const fallbackReportTarget = {
+  USER: "USER",
+  THREAD: "THREAD",
+  GIG: "GIG"
+} as const;
+
 function loadPrismaEnum<T extends Record<string, string>>(
   selector: (mod: Record<string, unknown>) => Record<string, string> | undefined,
   fallback: T
@@ -76,3 +117,39 @@ export const ApplicationStatus = loadPrismaEnum(
   fallbackApplicationStatus
 );
 export type ApplicationStatus = (typeof ApplicationStatus)[keyof typeof ApplicationStatus];
+
+export const ThreadState = loadPrismaEnum(
+  (mod) => mod.ThreadState as Record<string, string> | undefined,
+  fallbackThreadState
+);
+export type ThreadState = (typeof ThreadState)[keyof typeof ThreadState];
+
+export const MessageKind = loadPrismaEnum(
+  (mod) => mod.MessageKind as Record<string, string> | undefined,
+  fallbackMessageKind
+);
+export type MessageKind = (typeof MessageKind)[keyof typeof MessageKind];
+
+export const OfferStatus = loadPrismaEnum(
+  (mod) => mod.OfferStatus as Record<string, string> | undefined,
+  fallbackOfferStatus
+);
+export type OfferStatus = (typeof OfferStatus)[keyof typeof OfferStatus];
+
+export const BookingStatus = loadPrismaEnum(
+  (mod) => mod.BookingStatus as Record<string, string> | undefined,
+  fallbackBookingStatus
+);
+export type BookingStatus = (typeof BookingStatus)[keyof typeof BookingStatus];
+
+export const CancellationPolicy = loadPrismaEnum(
+  (mod) => mod.CancellationPolicy as Record<string, string> | undefined,
+  fallbackCancellationPolicy
+);
+export type CancellationPolicy = (typeof CancellationPolicy)[keyof typeof CancellationPolicy];
+
+export const ReportTarget = loadPrismaEnum(
+  (mod) => mod.ReportTarget as Record<string, string> | undefined,
+  fallbackReportTarget
+);
+export type ReportTarget = (typeof ReportTarget)[keyof typeof ReportTarget];

--- a/types/database.ts
+++ b/types/database.ts
@@ -1,8 +1,14 @@
 import type {
   ApplicationStatus,
+  BookingStatus,
+  CancellationPolicy,
   GigCompensationType,
   GigStatus,
+  MessageKind,
+  OfferStatus,
+  ReportTarget,
   Role,
+  ThreadState,
   VerificationStatus
 } from "@/lib/prismaEnums";
 
@@ -131,6 +137,83 @@ export interface FavoriteRecord {
   updatedAt: string;
 }
 
+export interface ThreadRecord {
+  id: string;
+  gigId: string;
+  createdById: string;
+  participantIds: string[];
+  state: ThreadState;
+  lastMessageAt: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface MessageRecord {
+  id: string;
+  threadId: string;
+  senderId: string;
+  kind: MessageKind;
+  body: string | null;
+  fileUrl: string | null;
+  offerId: string | null;
+  createdAt: string;
+}
+
+export interface OfferRecord {
+  id: string;
+  threadId: string;
+  fromUserId: string;
+  amount: number;
+  currency: string;
+  terms: string;
+  eventDate: string;
+  expiresAt: string | null;
+  status: OfferStatus;
+  createdAt: string;
+}
+
+export interface BookingRecord {
+  id: string;
+  gigId: string;
+  comedianId: string;
+  promoterId: string;
+  offerId: string;
+  status: BookingStatus;
+  payoutProtection: boolean;
+  cancellationPolicy: CancellationPolicy;
+  paymentIntentId: string | null;
+  createdAt: string;
+}
+
+export interface ConversationReviewRecord {
+  id: string;
+  bookingId: string;
+  fromUserId: string;
+  toUserId: string;
+  rating: number;
+  body: string;
+  visible: boolean;
+  createdAt: string;
+}
+
+export interface AvailabilityRecord {
+  id: string;
+  userId: string;
+  date: string;
+  status: "free" | "busy";
+}
+
+export interface ReportRecord {
+  id: string;
+  reporterId: string;
+  targetType: ReportTarget;
+  targetId: string;
+  reason: string;
+  details: string | null;
+  createdAt: string;
+  resolvedAt: string | null;
+}
+
 export interface DatabaseSnapshot {
   users: UserRecord[];
   comedianProfiles: ComedianProfileRecord[];
@@ -142,4 +225,11 @@ export interface DatabaseSnapshot {
   applications: ApplicationRecord[];
   verificationRequests: VerificationRequestRecord[];
   favorites: FavoriteRecord[];
+  threads: ThreadRecord[];
+  messages: MessageRecord[];
+  offers: OfferRecord[];
+  bookings: BookingRecord[];
+  conversationReviews: ConversationReviewRecord[];
+  availability: AvailabilityRecord[];
+  reports: ReportRecord[];
 }


### PR DESCRIPTION
## Summary
- extend the JSON datastore and enum helpers to support threads, offers, bookings, reviews, availability, and reports
- add REST API routes for messaging, offer decisions, mock payments, reviews, reporting, and profile strength insights
- seed sample conversation data, surface commerce copy, and build an inbox view that highlights offers and safety tips

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68de956978988323b7ecba4d13058221