### PR TITLE
Fix font loading errors and update typography styling

### DIFF
--- a/app/fonts.ts
+++ b/app/fonts.ts
@@ -2,4 +2,9 @@ import { Inter } from "next/font/google";
 import { Bricolage_Grotesque } from "next/font/google";
 
 export const inter = Inter({ subsets: ["latin"], variable: "--font-inter", display: "swap" });
-export const display = Bricolage_Grotesque({ subsets: ["latin"], variable: "--font-display", display: "swap" });
+export const display = Bricolage_Grotesque({
+  subsets: ["latin"],
+  variable: "--font-display",
+  display: "swap",
+  adjustFontFallback: false
+});

--- a/app/globals.css
+++ b/app/globals.css
@@ -7,7 +7,7 @@
 }
 
 body {
-  @apply min-h-screen bg-slate-100 text-slate-900 antialiased;
+  @apply min-h-screen bg-slate-100 text-slate-900 antialiased font-sans;
   background-image: radial-gradient(circle at 20% 20%, rgba(15, 23, 42, 0.08), transparent 55%),
     radial-gradient(circle at 80% 10%, rgba(252, 165, 165, 0.15), transparent 55%),
     radial-gradient(circle at 50% 100%, rgba(199, 210, 254, 0.2), transparent 55%);

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -166,7 +166,7 @@ export default function LandingPage() {
             {boardThreads.map((thread) => (
               <article key={thread.title} className="space-y-3 rounded-2xl border border-slate-200/80 p-4">
                 <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
-                  <h3 className="text-lg font-semibold text-slate-900">{thread.title}</h3>
+                  <h3 className="font-display text-lg font-semibold text-slate-900">{thread.title}</h3>
                   <span className="text-xs text-slate-500">Updated {thread.updated}</span>
                 </div>
                 <p className="text-sm text-slate-600">{thread.excerpt}</p>

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -12,7 +12,7 @@ export async function Navbar() {
       <div className="mx-auto flex w-full max-w-6xl items-center justify-between px-6 py-4">
         <Link
           href="/"
-          className="text-xl font-semibold text-brand transition hover:text-brand-dark focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40 focus-visible:ring-offset-2"
+          className="font-display text-xl font-semibold text-brand transition hover:text-brand-dark focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40 focus-visible:ring-offset-2"
         >
           the-funny
         </Link>

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -10,7 +10,7 @@ export function CardHeader({ className, ...props }: React.HTMLAttributes<HTMLDiv
 }
 
 export function CardTitle({ className, ...props }: React.HTMLAttributes<HTMLHeadingElement>) {
-  return <h3 className={cn("text-lg font-semibold", className)} {...props} />;
+  return <h3 className={cn("font-display text-lg font-semibold", className)} {...props} />;
 }
 
 export function CardContent({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,10 +1,15 @@
 import type { Config } from "tailwindcss";
+import defaultTheme from "tailwindcss/defaultTheme";
 import animatePlugin from "tailwindcss-animate";
 
 const config: Config = {
   content: ["./app/**/*.{js,ts,jsx,tsx}", "./components/**/*.{js,ts,jsx,tsx}"],
   theme: {
     extend: {
+      fontFamily: {
+        sans: ["var(--font-inter)", ...defaultTheme.fontFamily.sans],
+        display: ["var(--font-display)", ...defaultTheme.fontFamily.sans]
+      },
       colors: {
         brand: {
           DEFAULT: "#0f172a",


### PR DESCRIPTION
## Summary
- disable font fallback adjustment for Bricolage Grotesque to resolve the Next.js font override error
- wire Inter and Bricolage Grotesque into Tailwind/global styles and apply them to shared UI components
- refresh the landing page and navbar headings to use the display font consistently

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68de997599d8832381ec619c29a30569