### PR TITLE
Create minimal skeleton layout for the site

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -7,13 +7,9 @@
 }
 
 body {
-  @apply min-h-screen bg-slate-100 text-slate-900 antialiased font-sans;
-  background-image: radial-gradient(circle at 20% 20%, rgba(15, 23, 42, 0.08), transparent 55%),
-    radial-gradient(circle at 80% 10%, rgba(252, 165, 165, 0.15), transparent 55%),
-    radial-gradient(circle at 50% 100%, rgba(199, 210, 254, 0.2), transparent 55%);
-  background-attachment: fixed;
+  @apply min-h-screen bg-white text-slate-900 antialiased;
 }
 
 a {
-  @apply text-brand hover:text-brand-dark;
+  @apply text-slate-900 underline-offset-4 transition hover:text-slate-600;
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,25 +1,20 @@
 import "./globals.css";
 import { Navbar } from "@/components/navbar";
 import { ReactNode } from "react";
-import { inter, display } from "./fonts";
+import { inter } from "./fonts";
 
 export const metadata = {
   title: "the-funny",
-  description: "Connecting comedians, promoters, venues, and fans"
+  description: "A simple workspace for planning comedy shows.",
 };
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
-    <html lang="en" className={`${inter.variable} ${display.variable}`}>
-      <body className="relative min-h-screen bg-slate-100 text-slate-900 antialiased">
-        <div className="pointer-events-none absolute inset-0 overflow-hidden">
-          <div className="absolute left-1/2 top-[-15%] h-[32rem] w-[32rem] -translate-x-1/2 rounded-full bg-brand/10 blur-3xl" />
-          <div className="absolute -left-24 bottom-[-25%] h-[28rem] w-[28rem] rounded-full bg-indigo-200/60 blur-3xl" />
-          <div className="absolute -right-10 top-1/3 h-72 w-72 rounded-full bg-amber-100/70 blur-3xl" />
-        </div>
-        <div className="relative z-10 flex min-h-screen flex-col">
+    <html lang="en" className={inter.variable}>
+      <body className="bg-white text-slate-900 antialiased">
+        <div className="flex min-h-screen flex-col">
           <Navbar />
-          <main className="mx-auto w-full max-w-6xl flex-1 px-6 py-12">{children}</main>
+          <main className="mx-auto w-full max-w-4xl flex-1 px-4 py-12 sm:px-6 lg:px-8">{children}</main>
         </div>
       </body>
     </html>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,266 +1,49 @@
-import Link from "next/link";
-import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Icon } from "@/components/ui/Icon";
-
-const primaryActions = [
+const sections = [
   {
-    label: "Join as comedian",
-    description: "Lock in bookings faster with verified promoter and venue listings.",
-    href: "/auth/sign-up?role=COMEDIAN"
-  },
-  {
-    label: "Join as promoter",
-    description: "Post rooms, share run-of-show details, and manage applicants in one place.",
-    href: "/auth/sign-up?role=PROMOTER"
-  },
-  {
-    label: "Join as venue",
-    description: "Keep your calendar full by showcasing specs, payouts, and tech requirements.",
-    href: "/auth/sign-up?role=VENUE"
-  }
-];
-
-const boardThreads = [
-  {
-    title: "Looking for a late-night host in Chicago",
-    excerpt:
-      "Skyline Rooms needs a seasoned comic to host our Friday midnight mic. Share your tape and weekday availability.",
-    tags: ["Booking", "Chicago"],
-    replies: 12,
-    updated: "12 minutes ago"
-  },
-  {
-    title: "Room share: fully equipped black box in Austin",
-    excerpt:
-      "200-seat room available Sunday through Tuesday. Lights, sound, and door staff included. DM for rate sheet.",
-    tags: ["Venue", "Texas"],
-    replies: 6,
-    updated: "47 minutes ago"
-  },
-  {
-    title: "Workshop: building a tight festival set",
-    excerpt:
-      "Share feedback on 7-minute festival-ready sets. Recording swaps encouraged; constructive notes required.",
-    tags: ["Craft", "Feedback"],
-    replies: 18,
-    updated: "1 hour ago"
-  }
-];
-
-const quickLinks = [
-  {
-    label: "Post a gig opportunity",
-    icon: "CalendarPlus" as const,
-    href: "/gigs/post"
-  },
-  {
-    label: "Request avails from comedians",
-    icon: "CalendarSearch" as const,
-    href: "/dashboard/availability"
-  },
-  {
-    label: "Share production resources",
-    icon: "HardHat" as const,
-    href: "/dashboard/resources"
-  }
-];
-
-const profileHighlights = [
-  {
-    title: "Comedian profiles",
+    title: "Plan shows together",
     description:
-      "Keep avails, tech needs, reel, credits, and routing in one place so promoters can book without guesswork.",
-    icon: "Mic2" as const,
-    href: "/comedians"
+      "Collect details about rooms, lineups, and schedules in one shared workspace so everyone knows what happens next.",
   },
   {
-    title: "Venue profiles",
+    title: "Keep responsibilities clear",
     description:
-      "Publish room specs, payout models, load-in instructions, and contract templates to streamline every show night.",
-    icon: "Building2" as const,
-    href: "/venues"
-  }
-];
-
-const operationsNotes = [
-  {
-    title: "Background checks & verification",
-    description:
-      "Every promoter and venue is reviewed before posting so comics can share sensitive routing info with confidence.",
-    icon: "ShieldCheck" as const
+      "Outline who is booking, who is promoting, and what each night requires without getting lost in extra features.",
   },
   {
-    title: "Paperwork handled",
+    title: "Grow when you are ready",
     description:
-      "Generate deal memos, set payout schedules, and track W-9s right from the thread that kicked off the booking.",
-    icon: "FileSpreadsheet" as const
+      "This foundation keeps the essentials in view. Add the pieces you need later without rebuilding from scratch.",
   },
-  {
-    title: "Stay in sync",
-    description:
-      "Thread activity feeds directly into calendars, reminders, and group chats for your production team.",
-    icon: "BellRing" as const
-  }
 ];
 
 export default function LandingPage() {
   return (
-    <section className="space-y-10 pb-16">
-      <Card className="border border-slate-200 bg-white shadow-sm">
-        <CardHeader className="space-y-4">
-          <Badge variant="outline" className="w-fit border-brand/30 text-brand">
-            Working comedy bulletin
-          </Badge>
-          <CardTitle className="text-3xl font-semibold text-slate-900 sm:text-4xl">
-            the-funny workboard
-          </CardTitle>
-          <p className="max-w-2xl text-base text-slate-600">
-            Built for comedians, promoters, and venues to coordinate shows, swap resources, and keep the run-of-show tight.
-            No fan features—just the tools the industry relies on to make nights happen.
-          </p>
-        </CardHeader>
-        <CardContent className="space-y-8">
-          <div className="flex flex-wrap gap-3">
-            <Button asChild size="lg" className="gap-2 text-base">
-              <Link href="/dashboard">
-                Enter message board
-                <Icon name="ArrowRight" className="h-4 w-4" />
-              </Link>
-            </Button>
-            <Button asChild size="lg" variant="outline" className="gap-2 text-base text-brand">
-              <Link href="/gigs/post">
-                Post an opportunity
-                <Icon name="Plus" className="h-4 w-4" />
-              </Link>
-            </Button>
-          </div>
-          <div className="grid gap-4 md:grid-cols-3">
-            {primaryActions.map((action) => (
-              <div key={action.label} className="rounded-2xl border border-dashed border-slate-200 bg-slate-50/60 p-4">
-                <p className="text-sm font-semibold text-slate-800">{action.label}</p>
-                <p className="mt-2 text-sm text-slate-600">{action.description}</p>
-                <Button asChild variant="link" className="mt-3 h-auto p-0 text-sm text-brand">
-                  <Link href={action.href}>Create profile</Link>
-                </Button>
-              </div>
-            ))}
-          </div>
-        </CardContent>
-      </Card>
+    <div className="space-y-16">
+      <section className="space-y-6">
+        <p className="text-xs uppercase tracking-[0.3em] text-slate-500">Skeleton</p>
+        <h1 className="text-3xl font-semibold tracking-tight sm:text-4xl">the-funny workspace</h1>
+        <p className="max-w-2xl text-base text-slate-600">
+          A clean outline for connecting comedians, promoters, and venues. Start here, agree on the essentials, and layer in
+          more when the structure feels right.
+        </p>
+      </section>
 
-      <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_320px]">
-        <Card className="border border-slate-200 bg-white shadow-sm">
-          <CardHeader className="space-y-2">
-            <Badge variant="outline" className="w-fit border-slate-200 text-slate-600">
-              Live threads
-            </Badge>
-            <CardTitle className="text-2xl text-slate-900">Today on the board</CardTitle>
-            <p className="text-sm text-slate-600">
-              Threads stay focused on actionable details—drop avails, negotiate terms, and lock the lineup without leaving the
-              conversation.
-            </p>
-          </CardHeader>
-          <CardContent className="space-y-6">
-            {boardThreads.map((thread) => (
-              <article key={thread.title} className="space-y-3 rounded-2xl border border-slate-200/80 p-4">
-                <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
-                  <h3 className="font-display text-lg font-semibold text-slate-900">{thread.title}</h3>
-                  <span className="text-xs text-slate-500">Updated {thread.updated}</span>
-                </div>
-                <p className="text-sm text-slate-600">{thread.excerpt}</p>
-                <div className="flex flex-wrap items-center gap-3 text-xs text-slate-500">
-                  <div className="flex items-center gap-1 text-slate-600">
-                    <Icon name="MessageCircle" className="h-3.5 w-3.5" />
-                    {thread.replies} replies
-                  </div>
-                  {thread.tags.map((tag) => (
-                    <span key={tag} className="rounded-full bg-slate-100 px-3 py-1 text-slate-600">
-                      #{tag}
-                    </span>
-                  ))}
-                  <Button asChild variant="ghost" size="sm" className="ml-auto h-7 px-3 text-xs">
-                    <Link href="/dashboard">Open thread</Link>
-                  </Button>
-                </div>
-              </article>
-            ))}
-          </CardContent>
-        </Card>
-        <Card className="border border-slate-200 bg-slate-50 shadow-inner">
-          <CardHeader className="space-y-2">
-            <CardTitle className="text-lg text-slate-800">Quick actions</CardTitle>
-            <p className="text-sm text-slate-600">Keep the workflow moving with one-click tools.</p>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            {quickLinks.map((link) => (
-              <Button
-                key={link.label}
-                asChild
-                variant="ghost"
-                className="w-full justify-start gap-3 border border-slate-200 bg-white text-left text-sm font-medium text-slate-700 hover:border-brand/40"
-              >
-                <Link href={link.href}>
-                  <Icon name={link.icon} className="h-4 w-4 text-brand" />
-                  {link.label}
-                </Link>
-              </Button>
-            ))}
-            <div className="rounded-2xl border border-dashed border-slate-300 bg-white p-4 text-sm text-slate-600">
-              <p className="font-semibold text-slate-800">Need something else?</p>
-              <p className="mt-1">
-                Start a &quot;Help wanted&quot; thread and tag the city or tour leg you&apos;re working on. The community can jump in with
-                resources fast.
-              </p>
-            </div>
-          </CardContent>
-        </Card>
-      </div>
-
-      <div className="grid gap-6 md:grid-cols-2">
-        {profileHighlights.map((profile) => (
-          <Card key={profile.title} className="border border-slate-200 bg-white shadow-sm">
-            <CardHeader className="flex flex-row items-start gap-3">
-              <span className="flex h-10 w-10 items-center justify-center rounded-full bg-brand/10 text-brand">
-                <Icon name={profile.icon} className="h-5 w-5" />
-              </span>
-              <div>
-                <CardTitle className="text-xl text-slate-900">{profile.title}</CardTitle>
-                <p className="mt-1 text-sm text-slate-600">{profile.description}</p>
-              </div>
-            </CardHeader>
-            <CardContent>
-              <Button asChild variant="outline" className="border-brand/40 text-brand">
-                <Link href={profile.href}>Explore profiles</Link>
-              </Button>
-            </CardContent>
-          </Card>
+      <section className="grid gap-8 sm:grid-cols-2">
+        {sections.map((section) => (
+          <article key={section.title} className="space-y-3 rounded-lg border border-slate-200 p-6">
+            <h2 className="text-lg font-medium text-slate-900">{section.title}</h2>
+            <p className="text-sm text-slate-600">{section.description}</p>
+          </article>
         ))}
-      </div>
+      </section>
 
-      <Card className="border border-slate-200 bg-white shadow-sm">
-        <CardHeader className="space-y-2">
-          <Badge variant="outline" className="w-fit border-slate-200 text-slate-600">
-            Operations essentials
-          </Badge>
-          <CardTitle className="text-2xl text-slate-900">Why working comics stay here</CardTitle>
-          <p className="text-sm text-slate-600">
-            Every feature protects the people doing the work—no fan chatter, just logistics, accountability, and faster payouts.
-          </p>
-        </CardHeader>
-        <CardContent className="grid gap-4 md:grid-cols-3">
-          {operationsNotes.map((note) => (
-            <div key={note.title} className="space-y-2 rounded-2xl border border-slate-200/80 p-4">
-              <div className="flex items-center gap-2 text-slate-700">
-                <Icon name={note.icon} className="h-4 w-4 text-brand" />
-                <p className="text-sm font-semibold">{note.title}</p>
-              </div>
-              <p className="text-sm text-slate-600">{note.description}</p>
-            </div>
-          ))}
-        </CardContent>
-      </Card>
-    </section>
+      <section className="space-y-4 rounded-lg border border-dashed border-slate-200 p-6 text-sm text-slate-600">
+        <h2 className="text-base font-medium text-slate-900">What happens next?</h2>
+        <p>
+          Document your workflow, invite collaborators, and decide which tools belong here. This version keeps only the
+          backbone so that future layers are intentional.
+        </p>
+      </section>
+    </div>
   );
 }

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -1,45 +1,24 @@
 import Link from "next/link";
-import { auth } from "@/lib/auth";
-import { roleLabelMap } from "@/lib/rbac";
-import { Button } from "@/components/ui/button";
 
-export async function Navbar() {
-  const session = await auth();
-  const user = session?.user;
+const links = [
+  { href: "/", label: "Home" },
+  { href: "/gigs", label: "Gigs" },
+  { href: "/comedians", label: "Comedians" },
+];
 
+export function Navbar() {
   return (
-    <header className="sticky top-0 z-50 border-b border-white/40 bg-white/80 backdrop-blur">
-      <div className="mx-auto flex w-full max-w-6xl items-center justify-between px-6 py-4">
-        <Link
-          href="/"
-          className="font-display text-xl font-semibold text-brand transition hover:text-brand-dark focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40 focus-visible:ring-offset-2"
-        >
+    <header className="border-b border-slate-200 bg-white">
+      <div className="mx-auto flex w-full max-w-4xl items-center justify-between px-4 py-4 sm:px-6 lg:px-8">
+        <Link href="/" className="text-base font-semibold tracking-tight">
           the-funny
         </Link>
-        <nav className="flex items-center gap-4 text-sm font-medium text-slate-600">
-          <Link className="transition hover:text-brand" href="/gigs">
-            Gigs
-          </Link>
-          <Link className="transition hover:text-brand" href="/comedians">
-            Comedians
-          </Link>
-          {user?.role === "ADMIN" && (
-            <Link className="transition hover:text-brand" href="/admin">
-              Admin
+        <nav className="flex items-center gap-4 text-sm text-slate-600">
+          {links.map((link) => (
+            <Link key={link.href} href={link.href} className="transition hover:text-slate-900">
+              {link.label}
             </Link>
-          )}
-          {user ? (
-            <Link
-              href="/dashboard"
-              className="rounded-full border border-slate-200 px-3 py-1 text-xs text-slate-700 transition hover:border-brand/40 hover:text-brand"
-            >
-              {user.name ?? "Dashboard"} ({roleLabelMap[user.role]})
-            </Link>
-          ) : (
-            <Button asChild size="sm" className="shadow-sm">
-              <Link href="/auth/sign-in">Sign in</Link>
-            </Button>
-          )}
+          ))}
         </nav>
       </div>
     </header>


### PR DESCRIPTION
## Summary
- replace the landing page with a stripped-down outline focused on the core workflow
- simplify the global layout and navigation to remove decorative and account-driven elements
- reset global styling to a clean white canvas for future incremental layering

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e1918fd9548323ad150d42d46b8adb