### PR TITLE
Add open mic ingestion pipeline and public API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules
 .next
 .env
+.env.local
 uploads
 coverage
 .DS_Store

--- a/app/api/internal/openmics/ingest/route.ts
+++ b/app/api/internal/openmics/ingest/route.ts
@@ -1,0 +1,9 @@
+import { NextRequest, NextResponse } from "next/server";
+import { runOpenMicIngestion } from "@/lib/openmics/ingest";
+export async function POST(req: NextRequest) {
+  if (req.headers.get("x-ingest-secret") !== process.env.INGEST_SECRET) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+  await runOpenMicIngestion();
+  return NextResponse.json({ ok: true });
+}

--- a/app/api/open-mics/route.ts
+++ b/app/api/open-mics/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const city = searchParams.get("city") || undefined;
+  const state = searchParams.get("state") || undefined;
+  const q = searchParams.get("q")?.toLowerCase() || undefined;
+  const page = Number(searchParams.get("page") || 1);
+  const pageSize = Math.min(Number(searchParams.get("pageSize") || 25), 100);
+
+  const where:any = { status: "published" };
+  if (city) where.city = { equals: city };
+  if (state) where.state = { equals: state };
+  if (q) where.title = { contains: q, mode: "insensitive" };
+
+  where.OR = [
+    { startUtc: { gte: new Date() } },
+    { recurrence: { not: null } }
+  ];
+
+  const [total, data] = await Promise.all([
+    prisma.openMic.count({ where }),
+    prisma.openMic.findMany({
+      where,
+      orderBy: [{ startUtc: "asc" }],
+      skip: (page-1)*pageSize,
+      take: pageSize
+    })
+  ]);
+
+  return NextResponse.json({ data, pagination: { page, pageSize, total } });
+}

--- a/components/OpenMicList.tsx
+++ b/components/OpenMicList.tsx
@@ -1,0 +1,28 @@
+"use client";
+import { useEffect, useState } from "react";
+
+export default function OpenMicList({ city="Olympia", state="WA" }:{city?:string;state?:string}) {
+  const [rows, setRows] = useState<any[]>([]);
+  useEffect(() => {
+    const url = `/api/open-mics?city=${encodeURIComponent(city)}&state=${encodeURIComponent(state)}&pageSize=50`;
+    fetch(url).then(r=>r.json()).then(j=>setRows(j.data||[]));
+  }, [city,state]);
+
+  return (
+    <div className="grid gap-4 md:grid-cols-2">
+      {rows.map((r) => (
+        <div key={r.id} className="rounded-2xl p-4 shadow">
+          <div className="text-lg font-semibold">{r.title}</div>
+          <div className="text-sm opacity-80">
+            {r.startUtc ? new Date(r.startUtc).toLocaleString() : (r.recurrence||"Recurring")}
+          </div>
+          <div className="text-sm">{[r.venueName, r.city && `${r.city}, ${r.state||""}`].filter(Boolean).join(" • ")}</div>
+          <div className="mt-2 flex gap-3">
+            <a href={r.url} target="_blank" className="underline">Page</a>
+            {r.signupUrl && <a href={r.signupUrl} target="_blank" className="underline">Signup</a>}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/config/openmic.allowlist.ts
+++ b/config/openmic.allowlist.ts
@@ -1,0 +1,53 @@
+export const ALLOWED_DOMAINS = [
+  // National / directories
+  "badslava.com",
+  "nwstandup.com",
+
+  // PNW clubs & community
+  "tacomacomedyclub.com",
+  "spokanecomedyclub.com",
+  "seattlecomedyclub.com",
+  "heliumcomedy.com",
+  "portlandcomedy.com",
+  "brodythejokebroker.com",
+
+  // Alt-weeklies (often list mics)
+  "portlandmercury.com",
+  "thestranger.com",
+
+  // LA / NYC small set for travel comics
+  "hollywoodimprov.com",
+  "comedystore.com",
+  "groundlings.com",
+  "elysiantheater.com",
+  "newyorkimprov.com",
+  "gothamcomedyclub.com",
+  "newyorkcomedyclub.com",
+];
+
+export const PREFERRED_PATH_HINTS = [
+  "/open-mic", "/openmics", "/open-mic-signup", "/open-mic-night", "/calendar"
+];
+
+export const CSE_KEYWORDS = [
+  "\"open mic\" comedy",
+  "\"comedy open mic\"",
+  "stand up open mic",
+  "stand-up open mic",
+  "comedy mic signup",
+  "new material mic",
+];
+
+export const MEETUP_KEYWORDS = [
+  "comedy","stand up","stand-up","open mic","open-mic","comedians"
+];
+
+export const SEED_CITIES = [
+  { city: "Olympia", state: "WA" },
+  { city: "Seattle", state: "WA" },
+  { city: "Tacoma", state: "WA" },
+  { city: "Spokane", state: "WA" },
+  { city: "Portland", state: "OR" },
+  { city: "Los Angeles", state: "CA" },
+  { city: "New York", state: "NY" },
+];

--- a/lib/openmics/allowlist.ts
+++ b/lib/openmics/allowlist.ts
@@ -1,0 +1,25 @@
+import {
+  ALLOWED_DOMAINS, PREFERRED_PATH_HINTS, CSE_KEYWORDS, MEETUP_KEYWORDS, SEED_CITIES
+} from "@/config/openmic.allowlist";
+
+const envDomains = (process.env.OPENMIC_ALLOWED_SITES ?? "")
+  .split(";")
+  .map((d) => d.trim())
+  .filter(Boolean);
+
+export const Allowlist = {
+  domains: new Set<string>([...ALLOWED_DOMAINS, ...envDomains]),
+  preferredPathHints: PREFERRED_PATH_HINTS,
+  cseKeywords: CSE_KEYWORDS,
+  meetupKeywords: MEETUP_KEYWORDS,
+  seedCities: SEED_CITIES,
+};
+
+export function isAllowedUrl(url: string): boolean {
+  try { const u = new URL(url); return Array.from(Allowlist.domains).some(d => u.hostname.endsWith(d)); }
+  catch { return false; }
+}
+export function looksLikeOpenMicPath(pathname: string): boolean {
+  const p = pathname.toLowerCase();
+  return Allowlist.preferredPathHints.some(h => p.includes(h));
+}

--- a/lib/openmics/ingest.ts
+++ b/lib/openmics/ingest.ts
@@ -1,0 +1,55 @@
+import pLimit from "p-limit";
+import { prisma } from "@/lib/prisma";
+import { whenKeyFrom, hashForDedupe, isComedyMic } from "./utils";
+import * as meetup from "./sources/meetup";
+import * as cse from "./sources/cse";
+import * as reddit from "./sources/reddit";
+
+export async function runOpenMicIngestion() {
+  const cities = (process.env.DEFAULT_CITIES ?? "")
+    .split(";").map(s => { const [city,state] = s.split(",").map(x=>x.trim()); return { city, state }; })
+    .filter(c => c.city);
+
+  const args = {
+    cities,
+    radiusMiles: Number(process.env.DEFAULT_RADIUS_MILES ?? 50),
+    windowDays: Number(process.env.INGEST_WINDOW_DAYS ?? 60),
+    now: new Date(),
+  };
+
+  const sources = [
+    { name: "meetup", fn: meetup.fetchOpenMics },
+    { name: "cse", fn: cse.fetchOpenMics },
+  ];
+
+  if (process.env.ENABLE_REDDIT_OPENMICS === "true") {
+    sources.push({ name: "reddit", fn: reddit.fetchOpenMics });
+  }
+
+  const limit = pLimit(1);
+  for (const src of sources) {
+    await limit(async () => {
+      try {
+        const items = await src.fn(args);
+        let upserts = 0;
+        for (const e of items) {
+          if (!isComedyMic(`${e.title} ${e.description||""}`)) continue;
+          const whenKey = whenKeyFrom(e);
+          const scrapedHash = e.scrapedHash ?? hashForDedupe(e.title, whenKey, e.venueName);
+          const where = e.sourceId ? { source_sourceId: { source: e.source, sourceId: e.sourceId } } : undefined;
+
+          if (where) {
+            await prisma.openMic.upsert({ where, update: { ...e, scrapedHash }, create: { ...e, scrapedHash } });
+            upserts++;
+          } else {
+            const dup = await prisma.openMic.findFirst({ where: { scrapedHash } });
+            if (!dup) { await prisma.openMic.create({ data: { ...e, scrapedHash } }); upserts++; }
+          }
+        }
+        await prisma.ingestLog.create({ data: { source: src.name, succeeded: true, message: `ingested ${upserts}` } });
+      } catch (err:any) {
+        await prisma.ingestLog.create({ data: { source: src.name, succeeded: false, message: err?.message?.slice(0,512) } });
+      }
+    });
+  }
+}

--- a/lib/openmics/sources/cse.ts
+++ b/lib/openmics/sources/cse.ts
@@ -1,0 +1,100 @@
+import axios from "axios";
+import * as cheerio from "cheerio";
+import { NormalizedMic, NormalizedMicT } from "../types";
+import { Allowlist, isAllowedUrl, looksLikeOpenMicPath } from "../allowlist";
+import { isComedyMic, parseDayOfWeek } from "../utils";
+
+export type FetchArgs = {
+  cities: { city: string; state?: string }[];
+  radiusMiles: number;
+  windowDays: number;
+  now: Date;
+};
+
+const CSE_ENDPOINT = "https://www.googleapis.com/customsearch/v1";
+
+export async function fetchOpenMics(args: FetchArgs): Promise<NormalizedMicT[]> {
+  const out: NormalizedMicT[] = [];
+  const key = process.env.GOOGLE_CSE_KEY;
+  const cx  = process.env.GOOGLE_CSE_ID;
+  if (!key || !cx) return out;
+
+  const cities = args.cities.length ? args.cities : Allowlist.seedCities;
+  for (const { city, state } of cities) {
+    for (const kw of Allowlist.cseKeywords) {
+      for (const domain of Allowlist.domains) {
+        const q = `${kw} ${city} ${state ?? ""} site:${domain}`;
+        try {
+          const { data } = await axios.get(CSE_ENDPOINT, { params: { key, cx, q, num: 5 }});
+          const items = data?.items ?? [];
+          for (const it of items) {
+            const link: string = it?.link;
+            if (!link || !isAllowedUrl(link)) continue;
+
+            const preferred = looksLikeOpenMicPath(new URL(link).pathname);
+
+            const text = `${it?.title ?? ""} ${it?.snippet ?? ""}`;
+            const hasTime = /\b(\d{1,2}(:\d{2})?\s?(am|pm)|\b\d{2}:\d{2}\b)/i.test(text);
+            const dow = parseDayOfWeek(text);
+
+            if (!preferred && !hasTime && dow === undefined) continue;
+
+            let title = it?.title ?? "Open Mic";
+            let venue: string|undefined;
+            let address: string|undefined;
+            let signupUrl: string|undefined;
+            let recurrence: string|undefined;
+            let startUtc: Date|undefined;
+
+            try {
+              const html = await axios.get(link, { timeout: 10000 }).then(r => r.data);
+              const $ = cheerio.load(html);
+              const t = $("h1").first().text().trim() || $("title").text().trim() || title;
+              if (t) title = t;
+
+              const bodyText = $("body").text().replace(/\s+/g," ");
+              const timeMatch = bodyText.match(/\b(\d{1,2}(:\d{2})?\s?(AM|PM))\b/i);
+              const dow2 = parseDayOfWeek(bodyText) ?? dow;
+
+              venue = $('[itemprop="name"]').first().text().trim() || venue;
+              if (!venue) {
+                const vGuess = bodyText.match(/(at|@)\s+([A-Z][\w'&\s\-]{3,60})/i);
+                venue = vGuess?.[2];
+              }
+              const addressNode = $('[itemprop="streetAddress"]').first().text().trim();
+              if (addressNode) address = addressNode;
+
+              if (dow2 !== undefined && timeMatch) {
+                recurrence = `Weekly-ish ${["Sun","Mon","Tue","Wed","Thu","Fri","Sat"][dow2]} ${timeMatch[0].toUpperCase()}`;
+              }
+
+              const signSel = $('a:contains("sign")').first().attr("href") || $('a:contains("signup")').first().attr("href");
+              if (signSel) signupUrl = new URL(signSel, link).toString();
+            } catch { /* ignore page parse errors */ }
+
+            if (!isComedyMic(`${title}`)) continue;
+
+            const mic = NormalizedMic.parse({
+              source: "cse",
+              sourceId: link,
+              title,
+              description: it?.snippet,
+              url: link,
+              signupUrl,
+              dayOfWeek: undefined,
+              startUtc,
+              recurrence,
+              venueName: venue,
+              address,
+              city, state,
+              isFree: true,
+              tags: ["open-mic","comedy"],
+            });
+            out.push(mic);
+          }
+        } catch { /* keep going */ }
+      }
+    }
+  }
+  return out;
+}

--- a/lib/openmics/sources/meetup.ts
+++ b/lib/openmics/sources/meetup.ts
@@ -1,0 +1,53 @@
+import axios from "axios";
+import { NormalizedMic, NormalizedMicT } from "../types";
+import { Allowlist } from "../allowlist";
+import { isComedyMic } from "../utils";
+
+export type FetchArgs = {
+  cities: { city: string; state?: string }[];
+  radiusMiles: number;
+  windowDays: number;
+  now: Date;
+};
+
+export async function fetchOpenMics(args: FetchArgs): Promise<NormalizedMicT[]> {
+  const out: NormalizedMicT[] = [];
+  if (!process.env.MEETUP_TOKEN) return out;
+
+  const headers = { Authorization: `Bearer ${process.env.MEETUP_TOKEN}` };
+
+  const cities = args.cities.length ? args.cities : Allowlist.seedCities;
+  for (const { city, state } of cities) {
+    for (const kw of Allowlist.meetupKeywords) {
+      try {
+        const url = `https://api.meetup.com/find/upcoming_events?text=${encodeURIComponent(kw)}&radius=${args.radiusMiles}&fields=featured_photo&end_date_range=${new Date(args.now.getTime()+args.windowDays*864e5).toISOString()}&page=20&city=${encodeURIComponent(city)}${state?`&country=us&state=${encodeURIComponent(state)}`:""}`;
+        const { data } = await axios.get(url, { headers });
+        const events = data?.events ?? [];
+        for (const ev of events) {
+          const title = ev?.name ?? "";
+          const desc  = ev?.description ?? "";
+          if (!isComedyMic(`${title} ${desc}`)) continue;
+
+          const startUtc = ev?.time ? new Date(ev.time) : undefined;
+          const venue = ev?.venue?.name ?? ev?.group?.name;
+          const mic = NormalizedMic.parse({
+            source: "meetup",
+            sourceId: String(ev?.id ?? ""),
+            title,
+            description: desc,
+            url: ev?.link,
+            startUtc,
+            venueName: venue,
+            city,
+            state,
+            isFree: ev?.fee ? false : true,
+            tags: ["open-mic","comedy"],
+            imageUrl: ev?.featured_photo?.highres_link,
+          });
+          out.push(mic);
+        }
+      } catch (_e) { /* swallow per-city errors, continue */ }
+    }
+  }
+  return out;
+}

--- a/lib/openmics/sources/reddit.ts
+++ b/lib/openmics/sources/reddit.ts
@@ -1,0 +1,15 @@
+import { NormalizedMicT } from "../types";
+
+export type FetchArgs = {
+  cities: { city: string; state?: string }[];
+  radiusMiles: number;
+  windowDays: number;
+  now: Date;
+};
+
+export async function fetchOpenMics(_args: FetchArgs): Promise<NormalizedMicT[]> {
+  if (process.env.ENABLE_REDDIT_OPENMICS === "true") {
+    // TODO: Implement Reddit ingestion respecting API terms.
+  }
+  return [];
+}

--- a/lib/openmics/types.ts
+++ b/lib/openmics/types.ts
@@ -1,0 +1,30 @@
+import { z } from "zod";
+
+export const NormalizedMic = z.object({
+  source: z.string(),
+  sourceId: z.string().optional(),
+  title: z.string(),
+  description: z.string().optional(),
+  url: z.string().url(),
+  signupUrl: z.string().url().optional(),
+  dayOfWeek: z.number().int().min(0).max(6).optional(),
+  startUtc: z.coerce.date().optional(),
+  endUtc: z.coerce.date().optional(),
+  recurrence: z.string().optional(),
+  venueName: z.string().optional(),
+  address: z.string().optional(),
+  city: z.string().optional(),
+  state: z.string().optional(),
+  country: z.string().optional(),
+  lat: z.number().optional(),
+  lng: z.number().optional(),
+  isFree: z.boolean().optional(),
+  tags: z.array(z.string()).default([]),
+  imageUrl: z.string().url().optional(),
+  scrapedHash: z.string().optional(),
+});
+export type NormalizedMicT = z.infer<typeof NormalizedMic>;
+
+export const COMEDY_KEYWORDS = [
+  "open mic","open-mic","comedy open mic","stand up","stand-up","mic list","lottery","premic","workshop"
+];

--- a/lib/openmics/utils.ts
+++ b/lib/openmics/utils.ts
@@ -1,0 +1,26 @@
+import crypto from "crypto";
+
+export function isComedyMic(text?: string) {
+  if (!text) return false;
+  const t = text.toLowerCase();
+  return ["open mic","open-mic","comedy","stand up","stand-up"].some(k => t.includes(k));
+}
+
+export function hashForDedupe(title: string, whenKey: string, venue?: string) {
+  const base = `${title.toLowerCase()}|${whenKey}|${(venue||"").toLowerCase()}`;
+  return crypto.createHash("sha1").update(base).digest("hex");
+}
+
+export function whenKeyFrom(item: {startUtc?: Date; dayOfWeek?: number; recurrence?: string}) {
+  if (item.startUtc) return new Date(item.startUtc).toISOString();
+  if (typeof item.dayOfWeek === "number") return `DOW:${item.dayOfWeek}`;
+  return `REC:${(item.recurrence||"").slice(0,64)}`;
+}
+
+export function parseDayOfWeek(text: string): number | undefined {
+  const map: Record<string, number> = { sun:0, mon:1, tue:2, wed:3, thu:4, fri:5, sat:6 };
+  const m = text.toLowerCase().match(/\b(sun|mon|tue|tues|wed|thu|thur|thurs|fri|sat)(?:day)?\b/);
+  if (!m) return undefined;
+  const key = (m[1].replace("tues","tue").replace("thur","thu").replace("thurs","thu"));
+  return map[key];
+}

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -29,6 +29,7 @@ import {
   updateVenueProfile,
   deleteGig
 } from "@/lib/dataStore";
+import { PrismaClient } from "@prisma/client";
 import type {
   Application,
   ComedianAppearance,
@@ -234,6 +235,11 @@ async function hydrateComedianProfile(
     result.appearances = appearances;
   }
   return result;
+}
+
+const prismaClient: PrismaClient & { __patched?: true } = (globalThis as any).__prismaClient ?? new PrismaClient();
+if (process.env.NODE_ENV !== "production") {
+  (globalThis as any).__prismaClient = prismaClient;
 }
 
 export const prisma = {
@@ -449,5 +455,10 @@ export const prisma = {
     async create(args: { data: { userId: string; gigId?: string | null; venueId?: string | null } }) {
       return addFavorite(args.data);
     }
-  }
+  },
+  openMic: prismaClient.openMic,
+  ingestLog: prismaClient.ingestLog,
+  $transaction: prismaClient.$transaction.bind(prismaClient),
+  $disconnect: prismaClient.$disconnect.bind(prismaClient),
+  $connect: prismaClient.$connect.bind(prismaClient)
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@dicebear/core": "^9.2.4",
         "@heroicons/react": "^2.2.0",
         "@hookform/resolvers": "^3.3.4",
+        "@prisma/client": "^6.16.3",
         "@radix-ui/react-slot": "^1.0.2",
         "@tanstack/react-query": "^5.29.3",
         "@tanstack/react-table": "^8.9.1",
@@ -24,14 +25,18 @@
         "@trpc/react-query": "^11.0.0-rc.452",
         "@trpc/server": "^11.0.0-rc.452",
         "autoprefixer": "^10.4.16",
+        "axios": "^1.12.2",
         "bcryptjs": "^2.4.3",
+        "cheerio": "^1.1.2",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.0",
         "crypto-hash": "^4.0.0",
         "lucide-react": "^0.322.0",
         "next": "14.1.0",
         "next-auth": "^4.24.6",
+        "node-cron": "^4.2.1",
         "nodemailer": "^6.9.8",
+        "p-limit": "^7.1.1",
         "phosphor-react": "^1.4.1",
         "postcss": "^8.4.32",
         "prisma": "^5.10.2",
@@ -48,6 +53,7 @@
       "devDependencies": {
         "@types/bcryptjs": "^2.4.2",
         "@types/node": "^20.11.30",
+        "@types/node-cron": "^3.0.11",
         "@types/react": "^18.2.46",
         "@types/react-dom": "^18.2.18",
         "@typescript-eslint/eslint-plugin": "^7.1.0",
@@ -58,6 +64,7 @@
         "eslint-plugin-tailwindcss": "^3.13.0",
         "jsdom": "^23.0.1",
         "prettier": "^3.2.4",
+        "tsx": "^4.20.6",
         "typescript": "^5.3.3",
         "vitest": "^1.2.0"
       }
@@ -675,6 +682,448 @@
       },
       "peerDependencies": {
         "@dicebear/core": "^9.0.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.10.tgz",
+      "integrity": "sha512-0NFWnA+7l41irNuaSVlLfgNT12caWJVLzp5eAVhZ0z1qpxbockccEt3s+149rE64VUI3Ml2zt8Nv5JVc4QXTsw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.10.tgz",
+      "integrity": "sha512-dQAxF1dW1C3zpeCDc5KqIYuZ1tgAdRXNoZP7vkBIRtKZPYe2xVr/d3SkirklCHudW1B45tGiUlz2pUWDfbDD4w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.10.tgz",
+      "integrity": "sha512-LSQa7eDahypv/VO6WKohZGPSJDq5OVOo3UoFR1E4t4Gj1W7zEQMUhI+lo81H+DtB+kP+tDgBp+M4oNCwp6kffg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.10.tgz",
+      "integrity": "sha512-MiC9CWdPrfhibcXwr39p9ha1x0lZJ9KaVfvzA0Wxwz9ETX4v5CHfF09bx935nHlhi+MxhA63dKRRQLiVgSUtEg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.10.tgz",
+      "integrity": "sha512-JC74bdXcQEpW9KkV326WpZZjLguSZ3DfS8wrrvPMHgQOIEIG/sPXEN/V8IssoJhbefLRcRqw6RQH2NnpdprtMA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.10.tgz",
+      "integrity": "sha512-tguWg1olF6DGqzws97pKZ8G2L7Ig1vjDmGTwcTuYHbuU6TTjJe5FXbgs5C1BBzHbJ2bo1m3WkQDbWO2PvamRcg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.10.tgz",
+      "integrity": "sha512-3ZioSQSg1HT2N05YxeJWYR+Libe3bREVSdWhEEgExWaDtyFbbXWb49QgPvFH8u03vUPX10JhJPcz7s9t9+boWg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.10.tgz",
+      "integrity": "sha512-LLgJfHJk014Aa4anGDbh8bmI5Lk+QidDmGzuC2D+vP7mv/GeSN+H39zOf7pN5N8p059FcOfs2bVlrRr4SK9WxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.10.tgz",
+      "integrity": "sha512-oR31GtBTFYCqEBALI9r6WxoU/ZofZl962pouZRTEYECvNF/dtXKku8YXcJkhgK/beU+zedXfIzHijSRapJY3vg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.10.tgz",
+      "integrity": "sha512-5luJWN6YKBsawd5f9i4+c+geYiVEw20FVW5x0v1kEMWNq8UctFjDiMATBxLvmmHA4bf7F6hTRaJgtghFr9iziQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.10.tgz",
+      "integrity": "sha512-NrSCx2Kim3EnnWgS4Txn0QGt0Xipoumb6z6sUtl5bOEZIVKhzfyp/Lyw4C1DIYvzeW/5mWYPBFJU3a/8Yr75DQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.10.tgz",
+      "integrity": "sha512-xoSphrd4AZda8+rUDDfD9J6FUMjrkTz8itpTITM4/xgerAZZcFW7Dv+sun7333IfKxGG8gAq+3NbfEMJfiY+Eg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.10.tgz",
+      "integrity": "sha512-ab6eiuCwoMmYDyTnyptoKkVS3k8fy/1Uvq7Dj5czXI6DF2GqD2ToInBI0SHOp5/X1BdZ26RKc5+qjQNGRBelRA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.10.tgz",
+      "integrity": "sha512-NLinzzOgZQsGpsTkEbdJTCanwA5/wozN9dSgEl12haXJBzMTpssebuXR42bthOF3z7zXFWH1AmvWunUCkBE4EA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.10.tgz",
+      "integrity": "sha512-FE557XdZDrtX8NMIeA8LBJX3dC2M8VGXwfrQWU7LB5SLOajfJIxmSdyL/gU1m64Zs9CBKvm4UAuBp5aJ8OgnrA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.10.tgz",
+      "integrity": "sha512-3BBSbgzuB9ajLoVZk0mGu+EHlBwkusRmeNYdqmznmMc9zGASFjSsxgkNsqmXugpPk00gJ0JNKh/97nxmjctdew==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.10.tgz",
+      "integrity": "sha512-QSX81KhFoZGwenVyPoberggdW1nrQZSvfVDAIUXr3WqLRZGZqWk/P4T8p2SP+de2Sr5HPcvjhcJzEiulKgnxtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.10.tgz",
+      "integrity": "sha512-AKQM3gfYfSW8XRk8DdMCzaLUFB15dTrZfnX8WXQoOUpUBQ+NaAFCP1kPS/ykbbGYz7rxn0WS48/81l9hFl3u4A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.10.tgz",
+      "integrity": "sha512-7RTytDPGU6fek/hWuN9qQpeGPBZFfB4zZgcz2VK2Z5VpdUxEI8JKYsg3JfO0n/Z1E/6l05n0unDCNc4HnhQGig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.10.tgz",
+      "integrity": "sha512-5Se0VM9Wtq797YFn+dLimf2Zx6McttsH2olUBsDml+lm0GOCRVebRWUvDtkY4BWYv/3NgzS8b/UM3jQNh5hYyw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.10.tgz",
+      "integrity": "sha512-XkA4frq1TLj4bEMB+2HnI0+4RnjbuGZfet2gs/LNs5Hc7D89ZQBHQ0gL2ND6Lzu1+QVkjp3x1gIcPKzRNP8bXw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.10.tgz",
+      "integrity": "sha512-AVTSBhTX8Y/Fz6OmIVBip9tJzZEUcY8WLh7I59+upa5/GPhh2/aM6bvOMQySspnCCHvFi79kMtdJS1w0DXAeag==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.10.tgz",
+      "integrity": "sha512-fswk3XT0Uf2pGJmOpDB7yknqhVkJQkAQOcW/ccVOtfx05LkbWOaRAtn5SaqXypeKQra1QaEa841PgrSL9ubSPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.10.tgz",
+      "integrity": "sha512-ah+9b59KDTSfpaCg6VdJoOQvKjI33nTaQr4UluQwW7aEwZQsbMCfTmfEO4VyewOxx4RaDT/xCy9ra2GPWmO7Kw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.10.tgz",
+      "integrity": "sha512-QHPDbKkrGO8/cz9LKVnJU22HOi4pxZnZhhA2HYHez5Pz4JeffhDjf85E57Oyco163GnzNCVkZK0b/n4Y0UHcSw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.10.tgz",
+      "integrity": "sha512-9KpxSVFCu0iK1owoez6aC/s/EdUQLDN3adTxGCqxMVhrPDj6bt5dbrHDXUuq+Bs2vATFBBrQS5vdQ/Ed2P+nbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/regexpp": {
@@ -1391,7 +1840,6 @@
       "integrity": "sha512-JfNfAtXG+/lIopsvoZlZiH2k5yNx87mcTS4t9/S5oufM1nKdXYxOvpDC1XoTCFBa5cQh7uXnbMPsmZrwZY80xw==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=18.18"
       },
@@ -2949,6 +3397,13 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/node-cron": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/node-cron/-/node-cron-3.0.11.tgz",
+      "integrity": "sha512-0ikrnug3/IyneSHqCBeslAhlK2aBfYek1fGo4bP4QnZPmiqSGRK+Oy7ZMisLWkesffJvQ1cqAcBnJC+8+nxIAg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
@@ -3801,19 +4256,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@vitest/runner/node_modules/yocto-queue": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.1.tgz",
-      "integrity": "sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@vitest/snapshot": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-1.6.1.tgz",
@@ -4106,11 +4548,28 @@
         "postcss": "^8.1.0"
       }
     },
+    "node_modules/axios": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
+      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.4",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
     "node_modules/bcryptjs": {
       "version": "2.4.3",
       "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
       "integrity": "sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==",
       "license": "MIT"
+    },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "license": "ISC"
     },
     "node_modules/browserslist": {
       "version": "4.26.2",
@@ -4339,6 +4798,48 @@
         "node": ">=4"
       }
     },
+    "node_modules/cheerio": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.1.2.tgz",
+      "integrity": "sha512-IkxPpb5rS/d1IiLbHMgfPuS0FgiWTtFIm/Nj+2woXDLTZ7fOT2eqzgYbdMlLweqlHbsZjxEChoVK+7iph7jyQg==",
+      "license": "MIT",
+      "dependencies": {
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "encoding-sniffer": "^0.2.1",
+        "htmlparser2": "^10.0.0",
+        "parse5": "^7.3.0",
+        "parse5-htmlparser2-tree-adapter": "^7.1.0",
+        "parse5-parser-stream": "^7.1.2",
+        "undici": "^7.12.0",
+        "whatwg-mimetype": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.1"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+      }
+    },
+    "node_modules/cheerio-select": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
+      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-select": "^5.1.0",
+        "css-what": "^6.1.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
     "node_modules/class-variance-authority": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
@@ -4402,6 +4903,34 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
       }
     },
     "node_modules/css.escape": {
@@ -4628,6 +5157,128 @@
       "peer": true,
       "engines": {
         "node": ">=0.3.1"
+      }
+    },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/encoding-sniffer": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
+      "integrity": "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "^0.6.3",
+        "whatwg-encoding": "^3.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.10.tgz",
+      "integrity": "sha512-9RiGKvCwaqxO2owP61uQ4BgNborAQskMR6QusfWzQqv7AZOg5oGehdY2pRJMTKuwxd1IDBP4rSbI5lHzU7SMsQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.10",
+        "@esbuild/android-arm": "0.25.10",
+        "@esbuild/android-arm64": "0.25.10",
+        "@esbuild/android-x64": "0.25.10",
+        "@esbuild/darwin-arm64": "0.25.10",
+        "@esbuild/darwin-x64": "0.25.10",
+        "@esbuild/freebsd-arm64": "0.25.10",
+        "@esbuild/freebsd-x64": "0.25.10",
+        "@esbuild/linux-arm": "0.25.10",
+        "@esbuild/linux-arm64": "0.25.10",
+        "@esbuild/linux-ia32": "0.25.10",
+        "@esbuild/linux-loong64": "0.25.10",
+        "@esbuild/linux-mips64el": "0.25.10",
+        "@esbuild/linux-ppc64": "0.25.10",
+        "@esbuild/linux-riscv64": "0.25.10",
+        "@esbuild/linux-s390x": "0.25.10",
+        "@esbuild/linux-x64": "0.25.10",
+        "@esbuild/netbsd-arm64": "0.25.10",
+        "@esbuild/netbsd-x64": "0.25.10",
+        "@esbuild/openbsd-arm64": "0.25.10",
+        "@esbuild/openbsd-x64": "0.25.10",
+        "@esbuild/openharmony-arm64": "0.25.10",
+        "@esbuild/sunos-x64": "0.25.10",
+        "@esbuild/win32-arm64": "0.25.10",
+        "@esbuild/win32-ia32": "0.25.10",
+        "@esbuild/win32-x64": "0.25.10"
       }
     },
     "node_modules/eslint": {
@@ -5105,19 +5756,6 @@
         }
       }
     },
-    "node_modules/eslint-config-next/node_modules/get-tsconfig": {
-      "version": "4.10.1",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.10.1.tgz",
-      "integrity": "sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "resolve-pkg-maps": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
-      }
-    },
     "node_modules/eslint-config-next/node_modules/is-bun-module": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-bun-module/-/is-bun-module-2.0.0.tgz",
@@ -5155,16 +5793,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/eslint-config-next/node_modules/resolve-pkg-maps": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
-      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
     "node_modules/eslint-config-next/node_modules/semver": {
@@ -12617,11 +13245,30 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/form-data": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
       "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -12638,14 +13285,12 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/form-data/node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -12659,7 +13304,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
@@ -12672,7 +13316,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -12682,7 +13325,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -12697,7 +13339,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -12707,7 +13348,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -12717,7 +13357,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -12730,7 +13369,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -12746,7 +13384,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -12756,7 +13393,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -12781,7 +13417,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -12795,7 +13430,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -12808,7 +13442,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -12821,7 +13454,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -12837,7 +13469,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -12850,7 +13481,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -12860,7 +13490,6 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -12870,7 +13499,6 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
@@ -12906,6 +13534,19 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/get-tsconfig": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.10.1.tgz",
+      "integrity": "sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -12930,6 +13571,37 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/htmlparser2": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.0.0.tgz",
+      "integrity": "sha512-TwAZM+zE5Tq3lrEHvOlvwgj1XLWQCtaaibSN11Q+gGBAS7Y1uZSWwXXRe4iF6OXnaq1riyQAPFOBtYc77Mxq0g==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.1",
+        "entities": "^6.0.0"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/http-proxy-agent": {
@@ -12978,6 +13650,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/ignore": {
@@ -13344,6 +14028,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/node-cron": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-4.2.1.tgz",
+      "integrity": "sha512-lgimEHPE/QDgFlywTd8yTR61ptugX3Qer29efeyWw2rv259HtGBNn1vZVmp8lB9uo9wC0t/AT4iGqXxia+CJFg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/nodemailer": {
       "version": "6.10.1",
       "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.1.tgz",
@@ -13360,6 +14053,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
     "node_modules/oauth": {
@@ -13419,6 +14124,21 @@
         "url": "https://github.com/sponsors/panva"
       }
     },
+    "node_modules/p-limit": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-7.1.1.tgz",
+      "integrity": "sha512-i8PyM2JnsNChVSYWLr2BAjNoLi0BAYC+wecOnZnVV+YSNJkzP7cWmvI34dk0WArWfH9KwBHNoZI3P3MppImlIA==",
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
@@ -13429,10 +14149,34 @@
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
       "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz",
+      "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "^5.0.3",
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-parser-stream": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
+      "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^7.0.0"
       },
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
@@ -13442,7 +14186,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
       "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -13600,6 +14343,12 @@
         "fsevents": "2.3.3"
       }
     },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
+    },
     "node_modules/react": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
@@ -13693,11 +14442,27 @@
         "node": ">=8"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/rrweb-cssom": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.6.0.tgz",
       "integrity": "sha512-APM0Gt1KoXBz0iIkkdB/kfvGOwC4UuJFeG/c+yV7wSc7q96cG/kJ0HiYCnzivD9SB53cLV1MlHFNfOuPaadYSw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
     "node_modules/saxes": {
@@ -15111,6 +15876,26 @@
       "optional": true,
       "peer": true
     },
+    "node_modules/tsx": {
+      "version": "4.20.6",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.20.6.tgz",
+      "integrity": "sha512-ytQKuwgmrrkDTFP4LjR0ToE2nqgy886GpvRSpU0JAnrdBYppuY5rLkRUYPU1yCryb24SsKBTL/hlDQAEFVwtZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.25.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
@@ -15122,6 +15907,15 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.16.0.tgz",
+      "integrity": "sha512-QEg3HPMll0o3t2ourKwOeUAZ159Kn9mx5pnzHRQO8+Wixmh88YdZRiIwat0iNzNNXn0yoEtXJqFpyW7eM8BV7g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {
@@ -16121,7 +16915,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
       "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "iconv-lite": "0.6.3"
@@ -16130,31 +16923,10 @@
         "node": ">=18"
       }
     },
-    "node_modules/whatwg-encoding/node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/whatwg-encoding/node_modules/safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/whatwg-mimetype": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
       "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -16274,6 +17046,18 @@
       "peer": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.1.tgz",
+      "integrity": "sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/zod": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "vitest"
+    "test": "vitest",
+    "openmics:once": "tsx -r dotenv/config -e \"import('./lib/openmics/ingest').then(m=>m.runOpenMicIngestion())\"",
+    "openmics:cron": "node --loader tsx scripts/openmic-cron.ts"
   },
   "dependencies": {
     "@auth/prisma-adapter": "^1.0.7",
@@ -15,6 +17,7 @@
     "@dicebear/core": "^9.2.4",
     "@heroicons/react": "^2.2.0",
     "@hookform/resolvers": "^3.3.4",
+    "@prisma/client": "^6.16.3",
     "@radix-ui/react-slot": "^1.0.2",
     "@tanstack/react-query": "^5.29.3",
     "@tanstack/react-table": "^8.9.1",
@@ -26,14 +29,18 @@
     "@trpc/react-query": "^11.0.0-rc.452",
     "@trpc/server": "^11.0.0-rc.452",
     "autoprefixer": "^10.4.16",
+    "axios": "^1.12.2",
     "bcryptjs": "^2.4.3",
+    "cheerio": "^1.1.2",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.0",
     "crypto-hash": "^4.0.0",
     "lucide-react": "^0.322.0",
     "next": "14.1.0",
     "next-auth": "^4.24.6",
+    "node-cron": "^4.2.1",
     "nodemailer": "^6.9.8",
+    "p-limit": "^7.1.1",
     "phosphor-react": "^1.4.1",
     "postcss": "^8.4.32",
     "prisma": "^5.10.2",
@@ -50,6 +57,7 @@
   "devDependencies": {
     "@types/bcryptjs": "^2.4.2",
     "@types/node": "^20.11.30",
+    "@types/node-cron": "^3.0.11",
     "@types/react": "^18.2.46",
     "@types/react-dom": "^18.2.18",
     "@typescript-eslint/eslint-plugin": "^7.1.0",
@@ -60,6 +68,7 @@
     "eslint-plugin-tailwindcss": "^3.13.0",
     "jsdom": "^23.0.1",
     "prettier": "^3.2.4",
+    "tsx": "^4.20.6",
     "typescript": "^5.3.3",
     "vitest": "^1.2.0"
   }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -3,7 +3,7 @@ generator client {
 }
 
 datasource db {
-  provider = "sqlite"
+  provider = "postgresql"
   url      = env("DATABASE_URL")
 }
 
@@ -234,4 +234,44 @@ model Message {
   createdAt DateTime @default(now())
   thread    MessageThread @relation(fields: [threadId], references: [id], onDelete: Cascade)
   sender    User      @relation(fields: [senderId], references: [id], onDelete: Cascade)
+}
+
+model OpenMic {
+  id          String   @id @default(cuid())
+  source      String
+  sourceId    String?
+  title       String
+  description String?
+  url         String
+  signupUrl   String?
+  dayOfWeek   Int?
+  startUtc    DateTime?
+  endUtc      DateTime?
+  recurrence  String?
+  venueName   String?
+  address     String?
+  city        String?
+  state       String?
+  country     String?  @default("US")
+  lat         Float?
+  lng         Float?
+  isFree      Boolean? @default(true)
+  tags        String[]
+  imageUrl    String?
+  scrapedHash String?
+  status      String   @default("published")
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  @@unique([source, sourceId])
+  @@index([city, state, dayOfWeek])
+  @@index([startUtc, city, state])
+}
+
+model IngestLog {
+  id        String   @id @default(cuid())
+  source    String
+  succeeded Boolean
+  message   String?
+  createdAt DateTime @default(now())
 }

--- a/scripts/openmic-cron.ts
+++ b/scripts/openmic-cron.ts
@@ -1,0 +1,6 @@
+import "dotenv/config";
+import cron from "node-cron";
+import { runOpenMicIngestion } from "../lib/openmics/ingest";
+cron.schedule(process.env.JOB_INTERVAL_CRON ?? "*/10 * * * *", async () => {
+  await runOpenMicIngestion();
+});


### PR DESCRIPTION
## Summary
- configure new open-mic allowlist utilities, shared schemas, and ingestion helpers for Google CSE and Meetup sources
- add Prisma models plus ingestion orchestration with cron/script entrypoints and internal trigger route
- expose a public open-mic API and minimal client component alongside dependency and script updates

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e1a1586a448323a552c8d8c81a5505