### PR TITLE
Fix avatar generation error on comedians page

### DIFF
--- a/app/comedians/page.tsx
+++ b/app/comedians/page.tsx
@@ -35,12 +35,10 @@ export default async function ComediansPage() {
     }
   });
 
-  const enriched = await Promise.all(
-    comedians.map(async (comedian) => ({
-      ...comedian,
-      avatar: comedian.user?.image ?? (await avatarDataUrl(comedian.userId))
-    }))
-  );
+  const enriched = comedians.map((comedian) => ({
+    ...comedian,
+    avatar: comedian.user?.image ?? avatarDataUrl(comedian.userId)
+  }));
 
   return (
     <div className="space-y-10">

--- a/lib/assets/avatar.ts
+++ b/lib/assets/avatar.ts
@@ -1,9 +1,9 @@
 import { createAvatar } from "@dicebear/core";
 import { botttsNeutral } from "@dicebear/collection";
-import { sha256 } from "crypto-hash";
+import { createHash } from "crypto";
 
-export async function avatarDataUrl(seed: string) {
-  const hashed = await sha256(seed);
+export function avatarDataUrl(seed: string) {
+  const hashed = createHash("sha256").update(seed).digest("hex");
   const svg = createAvatar(botttsNeutral, {
     seed: hashed,
     size: 96,

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,6 @@
         "cheerio": "^1.1.2",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.0",
-        "crypto-hash": "^4.0.0",
         "lucide-react": "^0.322.0",
         "next": "14.1.0",
         "next-auth": "^4.24.6",
@@ -4892,18 +4891,6 @@
       "license": "MIT",
       "optional": true,
       "peer": true
-    },
-    "node_modules/crypto-hash": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/crypto-hash/-/crypto-hash-4.0.0.tgz",
-      "integrity": "sha512-KkkFriWj2teXIJOmftIRavBL4q8A7EZV24Nn9sWhIR4hdeS8u+q2A2p0tWZ1m4xVoP1zs3VJjVwwAUnztBb8uw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/css-select": {
       "version": "5.2.2",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "cheerio": "^1.1.2",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.0",
-    "crypto-hash": "^4.0.0",
     "lucide-react": "^0.322.0",
     "next": "14.1.0",
     "next-auth": "^4.24.6",


### PR DESCRIPTION
## Summary
- replace the crypto-hash-based avatar generation with Node's crypto module to avoid runtime failures
- simplify the comedians listing enrichment logic and remove the unused crypto-hash dependency

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e1a8d24c7c83238f5a3ce0572bb53a