### PR TITLE
Enhance community board gig applications

### DIFF
--- a/lib/dataStore.ts
+++ b/lib/dataStore.ts
@@ -337,6 +337,13 @@ function mapOffer(record: OfferRecord): Offer {
 function mapCommunityBoardMessage(record: CommunityBoardMessageRecord): CommunityBoardMessage {
   return {
     ...record,
+    gigTitle: record.gigTitle ?? null,
+    gigAddress: record.gigAddress ?? null,
+    gigCity: record.gigCity ?? null,
+    gigState: record.gigState ?? null,
+    gigContactName: record.gigContactName ?? null,
+    gigContactEmail: record.gigContactEmail ?? null,
+    gigSlotsAvailable: record.gigSlotsAvailable ?? null,
     content: record.content,
     createdAt: new Date(record.createdAt),
     updatedAt: new Date(record.updatedAt)
@@ -1034,6 +1041,13 @@ interface CreateCommunityBoardMessageInput {
   authorRole: Role;
   content: string;
   category: CommunityBoardCategory;
+  gigTitle?: string | null;
+  gigAddress?: string | null;
+  gigCity?: string | null;
+  gigState?: string | null;
+  gigContactName?: string | null;
+  gigContactEmail?: string | null;
+  gigSlotsAvailable?: number | null;
 }
 
 export async function createCommunityBoardMessage(
@@ -1048,6 +1062,13 @@ export async function createCommunityBoardMessage(
     content: sanitizeHtml(input.content),
     category: input.category,
     isPinned: false,
+    gigTitle: input.gigTitle ? sanitizeHtml(input.gigTitle) : null,
+    gigAddress: input.gigAddress ? sanitizeHtml(input.gigAddress) : null,
+    gigCity: input.gigCity ? sanitizeHtml(input.gigCity) : null,
+    gigState: input.gigState ? sanitizeHtml(input.gigState) : null,
+    gigContactName: input.gigContactName ? sanitizeHtml(input.gigContactName) : null,
+    gigContactEmail: input.gigContactEmail ? sanitizeHtml(input.gigContactEmail) : null,
+    gigSlotsAvailable: input.gigSlotsAvailable ?? null,
     createdAt: now,
     updatedAt: now
   };

--- a/lib/zodSchemas.ts
+++ b/lib/zodSchemas.ts
@@ -94,6 +94,38 @@ export const venueProfileFormSchema = z.object({
 export const communityBoardMessageSchema = z.object({
   content: z.string().trim().min(1).max(1000),
   category: boardCategoryEnum,
+  gigTitle: z.string().trim().min(3).max(120).optional(),
+  gigAddress: z.string().trim().min(5).max(200).optional(),
+  gigCity: z.string().trim().min(2).max(80).optional(),
+  gigState: z
+    .string()
+    .trim()
+    .regex(/^[A-Z]{2}$/u, "State must be a 2-letter code")
+    .optional(),
+  gigContactName: z.string().trim().min(2).max(120).optional(),
+  gigContactEmail: z.string().trim().email().optional(),
+  gigSlotsAvailable: z.coerce.number().int().min(1).max(50).optional(),
+}).superRefine((data, ctx) => {
+  if (data.category === "OFFER") {
+    const requiredFields: Array<[keyof typeof data, unknown, string]> = [
+      ["gigTitle", data.gigTitle, "Provide a short gig title."],
+      ["gigAddress", data.gigAddress, "Include the street address for the gig."],
+      ["gigCity", data.gigCity, "Add the city where the show takes place."],
+      ["gigState", data.gigState, "Select the state or province for the gig."],
+      ["gigContactName", data.gigContactName, "Name the primary point of contact."],
+      ["gigContactEmail", data.gigContactEmail, "Add an email address for applications."],
+      ["gigSlotsAvailable", data.gigSlotsAvailable, "Share how many slots are open."],
+    ];
+    for (const [field, value, message] of requiredFields) {
+      if (value === undefined || value === null || value === "") {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: [field],
+          message,
+        });
+      }
+    }
+  }
 });
 
 export const communityBoardMessageUpdateSchema = z

--- a/types/database.ts
+++ b/types/database.ts
@@ -96,6 +96,13 @@ export interface CommunityBoardMessageRecord {
   content: string;
   category: CommunityBoardCategory;
   isPinned: boolean;
+  gigTitle: string | null;
+  gigAddress: string | null;
+  gigCity: string | null;
+  gigState: string | null;
+  gigContactName: string | null;
+  gigContactEmail: string | null;
+  gigSlotsAvailable: number | null;
   createdAt: string;
   updatedAt: string;
 }


### PR DESCRIPTION
## Summary
- add gig detail fields and contact metadata to community board messages with validation and persistence updates
- enrich board APIs with promoter and venue context so listings surface the posting profile
- redesign the profile message board to capture structured gig details and provide a guided application form for comedians

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e1af4b0a0c832395a6bfe35b7ef582