### PR TITLE
chore: scaffold prisma schema and ingestion skeleton

### DIFF
--- a/lib/db/client.ts
+++ b/lib/db/client.ts
@@ -1,0 +1,31 @@
+import { PrismaClient } from "@prisma/client";
+
+let prisma: PrismaClient | null = null;
+
+export function isDatabaseEnabled(): boolean {
+  return Boolean(process.env.DATABASE_URL);
+}
+
+export function getPrismaClient(): PrismaClient {
+  if (!isDatabaseEnabled()) {
+    throw new Error("DATABASE_URL is not configured; falling back to JSON store");
+  }
+  if (!prisma) {
+    prisma = new PrismaClient({
+      log:
+        process.env.NODE_ENV === "development"
+          ? ["error", "warn"]
+          : ["error"],
+    });
+  }
+  return prisma;
+}
+
+export function disconnectPrisma(): Promise<void> {
+  if (prisma) {
+    const client = prisma;
+    prisma = null;
+    return client.$disconnect();
+  }
+  return Promise.resolve();
+}

--- a/lib/db/gigs.ts
+++ b/lib/db/gigs.ts
@@ -1,0 +1,163 @@
+import { GigStatus, GigType, SignUpMethod } from "@prisma/client";
+import type { Prisma } from "@prisma/client";
+import { listGigs as listJsonGigs } from "@/lib/dataStore";
+import type { Gig as JsonGig } from "@/lib/dataStore";
+import { getPrismaClient, isDatabaseEnabled } from "./client";
+
+type MaybeDate = string | Date | null | undefined;
+
+export interface GigFilters {
+  query?: string;
+  type?: GigType;
+  city?: string;
+  startDate?: MaybeDate;
+  endDate?: MaybeDate;
+  bringer?: boolean;
+  signUpMethod?: SignUpMethod;
+  payMin?: number;
+  payMax?: number;
+  status?: GigStatus;
+  take?: number;
+  skip?: number;
+}
+
+export interface GigSummary {
+  id: string;
+  title: string;
+  description: string;
+  type: GigType;
+  status: GigStatus;
+  startsAt: Date;
+  endsAt: Date | null;
+  venueName?: string | null;
+  city?: string | null;
+  promoterName?: string | null;
+  signUpMethod: SignUpMethod;
+  bringer: boolean;
+  payMin?: number | null;
+  payMax?: number | null;
+  externalUrl?: string | null;
+}
+
+function coerceDate(value: MaybeDate): Date | undefined {
+  if (!value) return undefined;
+  if (value instanceof Date) return value;
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return undefined;
+  return parsed;
+}
+
+function mapJsonGig(gig: JsonGig): GigSummary {
+  return {
+    id: gig.id,
+    title: gig.title,
+    description: gig.description,
+    type: GigType.OPEN_MIC,
+    status: gig.isPublished ? GigStatus.PUBLISHED : GigStatus.DRAFT,
+    startsAt: gig.dateStart,
+    endsAt: gig.dateEnd,
+    venueName: gig.city,
+    city: gig.city,
+    promoterName: undefined,
+    signUpMethod: SignUpMethod.WALKUP,
+    bringer: false,
+    payMin: gig.payoutUsd ?? null,
+    payMax: gig.payoutUsd ?? null,
+    externalUrl: undefined,
+  };
+}
+
+export async function listPublishedGigs(filters: GigFilters = {}): Promise<GigSummary[]> {
+  if (isDatabaseEnabled()) {
+    const prisma = getPrismaClient();
+    const where: Prisma.GigWhereInput = {
+      status: filters.status ?? GigStatus.PUBLISHED,
+    };
+    if (filters.type) {
+      where.type = filters.type;
+    }
+    if (filters.bringer !== undefined) {
+      where.bringer = filters.bringer;
+    }
+    if (filters.signUpMethod) {
+      where.signUpMethod = filters.signUpMethod;
+    }
+    if (filters.payMin !== undefined || filters.payMax !== undefined) {
+      where.AND = where.AND ?? [];
+      const range: Prisma.GigWhereInput = {};
+      if (filters.payMin !== undefined) {
+        range.OR = [
+          { payMin: { gte: filters.payMin } },
+          { payMax: { gte: filters.payMin } },
+        ];
+      }
+      if (filters.payMax !== undefined) {
+        range.OR = [
+          ...(range.OR ?? []),
+          { payMin: { lte: filters.payMax } },
+          { payMax: { lte: filters.payMax } },
+        ];
+      }
+      (where.AND as Prisma.GigWhereInput[]).push(range);
+    }
+    if (filters.query) {
+      where.OR = [
+        ...(where.OR ?? []),
+        { title: { contains: filters.query, mode: "insensitive" } },
+        { description: { contains: filters.query, mode: "insensitive" } },
+      ];
+    }
+    const start = coerceDate(filters.startDate);
+    const end = coerceDate(filters.endDate);
+    if (start || end) {
+      where.startsAt = {};
+      if (start) where.startsAt.gte = start;
+      if (end) where.startsAt.lte = end;
+    }
+    if (filters.city) {
+      where.OR = [
+        ...(where.OR ?? []),
+        { venue: { address: { contains: filters.city, mode: "insensitive" } } },
+        { venue: { name: { contains: filters.city, mode: "insensitive" } } },
+      ];
+    }
+    const gigs = await prisma.gig.findMany({
+      where,
+      include: {
+        venue: true,
+        promoter: { include: { user: true } },
+      },
+      orderBy: { startsAt: "asc" },
+      take: filters.take ?? 50,
+      skip: filters.skip ?? 0,
+    });
+    return gigs.map((gig) => ({
+      id: gig.id,
+      title: gig.title,
+      description: gig.description,
+      type: gig.type,
+      status: gig.status,
+      startsAt: gig.startsAt,
+      endsAt: gig.endsAt,
+      venueName: gig.venue?.name,
+      city: gig.venue?.address ?? undefined,
+      promoterName: gig.promoter?.orgName ?? gig.promoter?.user?.email ?? undefined,
+      signUpMethod: gig.signUpMethod,
+      bringer: gig.bringer,
+      payMin: gig.payMin,
+      payMax: gig.payMax,
+      externalUrl: gig.externalUrl,
+    }));
+  }
+
+  const gigs = await listJsonGigs({
+    isPublished: filters.status ? filters.status === GigStatus.PUBLISHED : true,
+    titleContains: filters.query
+      ? { value: filters.query, mode: "insensitive" }
+      : undefined,
+    cityContains: filters.city ? { value: filters.city, mode: "insensitive" } : undefined,
+    minPayout: filters.payMin,
+    orderByDateStart: "asc",
+  });
+  return gigs.map(mapJsonGig);
+}

--- a/lib/db/leads.ts
+++ b/lib/db/leads.ts
@@ -1,0 +1,160 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import crypto from "node:crypto";
+import { LeadStatus } from "@prisma/client";
+import { getPrismaClient, isDatabaseEnabled } from "./client";
+
+export interface LeadInput {
+  source: string;
+  url: string;
+  title?: string | null;
+  raw?: unknown;
+  normalized?: unknown;
+  status?: LeadStatus;
+}
+
+export interface LeadRecord {
+  id: string;
+  source: string;
+  url: string;
+  title?: string | null;
+  raw?: unknown;
+  normalized?: unknown;
+  seenHash?: string | null;
+  status: LeadStatus;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const FALLBACK_FILE = path.join(process.cwd(), "data", "leads.json");
+
+async function ensureFallbackFile(): Promise<void> {
+  await fs.mkdir(path.dirname(FALLBACK_FILE), { recursive: true });
+  try {
+    await fs.access(FALLBACK_FILE);
+  } catch {
+    await fs.writeFile(FALLBACK_FILE, "[]", "utf8");
+  }
+}
+
+async function readFallback(): Promise<LeadRecord[]> {
+  await ensureFallbackFile();
+  const raw = await fs.readFile(FALLBACK_FILE, "utf8");
+  const parsed = JSON.parse(raw) as LeadRecord[];
+  return parsed.map((lead) => ({
+    ...lead,
+    createdAt: new Date(lead.createdAt),
+    updatedAt: new Date(lead.updatedAt),
+  }));
+}
+
+async function writeFallback(leads: LeadRecord[]): Promise<void> {
+  await fs.writeFile(
+    FALLBACK_FILE,
+    JSON.stringify(
+      leads.map((lead) => ({
+        ...lead,
+        createdAt: lead.createdAt.toISOString(),
+        updatedAt: lead.updatedAt.toISOString(),
+      })),
+      null,
+      2,
+    ),
+    "utf8",
+  );
+}
+
+function hashUrl(url: string): string {
+  return crypto.createHash("sha256").update(url).digest("hex");
+}
+
+export async function upsertLead(input: LeadInput): Promise<LeadRecord> {
+  if (isDatabaseEnabled()) {
+    const prisma = getPrismaClient();
+    const seenHash = hashUrl(input.url);
+    const now = new Date();
+    const lead = await prisma.lead.upsert({
+      where: { url: input.url },
+      create: {
+        source: input.source,
+        url: input.url,
+        title: input.title ?? null,
+        raw: input.raw ?? null,
+        normalized: input.normalized ?? null,
+        seenHash,
+        status: input.status ?? LeadStatus.NEW,
+      },
+      update: {
+        title: input.title ?? null,
+        raw: input.raw ?? null,
+        normalized: input.normalized ?? null,
+        status: input.status ?? LeadStatus.NEW,
+        seenHash,
+        updatedAt: now,
+      },
+    });
+    return {
+      ...lead,
+      createdAt: lead.createdAt,
+      updatedAt: lead.updatedAt,
+    };
+  }
+
+  const leads = await readFallback();
+  const existingIndex = leads.findIndex((lead) => lead.url === input.url);
+  const now = new Date();
+  const record: LeadRecord = {
+    id: existingIndex >= 0 ? leads[existingIndex].id : crypto.randomUUID(),
+    source: input.source,
+    url: input.url,
+    title: input.title ?? null,
+    raw: input.raw ?? null,
+    normalized: input.normalized ?? null,
+    seenHash: hashUrl(input.url),
+    status: input.status ?? LeadStatus.NEW,
+    createdAt: existingIndex >= 0 ? leads[existingIndex].createdAt : now,
+    updatedAt: now,
+  };
+  if (existingIndex >= 0) {
+    leads[existingIndex] = record;
+  } else {
+    leads.push(record);
+  }
+  await writeFallback(leads);
+  return record;
+}
+
+export async function listLeads(status?: LeadStatus): Promise<LeadRecord[]> {
+  if (isDatabaseEnabled()) {
+    const prisma = getPrismaClient();
+    const leads = await prisma.lead.findMany({
+      where: status ? { status } : undefined,
+      orderBy: { createdAt: "desc" },
+    });
+    return leads.map((lead) => ({
+      ...lead,
+      createdAt: lead.createdAt,
+      updatedAt: lead.updatedAt,
+    }));
+  }
+  const leads = await readFallback();
+  return status ? leads.filter((lead) => lead.status === status) : leads;
+}
+
+export async function updateLeadStatus(id: string, status: LeadStatus): Promise<void> {
+  if (isDatabaseEnabled()) {
+    const prisma = getPrismaClient();
+    await prisma.lead.update({
+      where: { id },
+      data: { status },
+    });
+    return;
+  }
+  const leads = await readFallback();
+  const index = leads.findIndex((lead) => lead.id === id);
+  if (index >= 0) {
+    leads[index].status = status;
+    leads[index].updatedAt = new Date();
+    await writeFallback(leads);
+  }
+}

--- a/lib/ingest/allowlist.ts
+++ b/lib/ingest/allowlist.ts
@@ -1,0 +1,27 @@
+import type { AllowlistSource } from "@prisma/client";
+
+export interface AllowlistEntry {
+  domain: string;
+  label: string;
+  enabled: boolean;
+}
+
+export const STARTER_ALLOWLIST: AllowlistEntry[] = [
+  { domain: "badslava.com", label: "BadSlava", enabled: true },
+  { domain: "openmic.us", label: "OpenMic.US", enabled: true },
+  { domain: "openmikes.org", label: "OpenMikes.org", enabled: true },
+  { domain: "nwstandup.com", label: "Northwest Standup", enabled: true },
+  { domain: "seattlesoundcomedy.com", label: "Seattle Sound Comedy", enabled: true },
+  { domain: "comedylistings.com", label: "Comedy Listings (PDX/SEA)", enabled: true },
+  { domain: "comedyunderground.com", label: "Comedy Underground (SEA)", enabled: true },
+  { domain: "lacomedyguide.com", label: "LA Comedy Guide", enabled: true },
+  {
+    domain: "reddit.com/r/Standup/wiki/local_groups",
+    label: "r/Standup wiki",
+    enabled: true,
+  },
+];
+
+export type AllowlistSourceRecord = Pick<AllowlistSource, "id" | "domain" | "label" | "enabled" | "lastCheckedAt">;
+
+export const ALLOWLIST_DOC = `The Funny ingestion allowlist only queries public gig calendars. Respect each site's robots.txt and honor request rate limits. Private or paid platforms like Eventbrite or Ticketmaster are excluded.`;

--- a/lib/ingest/normalize.ts
+++ b/lib/ingest/normalize.ts
@@ -1,0 +1,33 @@
+import { parseISO } from "date-fns";
+
+export interface NormalizedLead {
+  title?: string;
+  startsAt?: string;
+  venue?: {
+    name?: string;
+    address?: string;
+  };
+  signUpHint?: string;
+  externalUrl?: string;
+}
+
+function extractDate(text?: string): string | undefined {
+  if (!text) return undefined;
+  const match = text.match(/\b(\d{4}-\d{2}-\d{2})\b/);
+  if (match) {
+    const date = parseISO(match[1]);
+    if (!Number.isNaN(date.getTime())) {
+      return date.toISOString();
+    }
+  }
+  return undefined;
+}
+
+export function normalizeLeadFromSnippet(snippet?: string): NormalizedLead {
+  if (!snippet) return {};
+  const startsAt = extractDate(snippet);
+  return {
+    startsAt,
+    signUpHint: snippet,
+  };
+}

--- a/lib/ingest/runner.ts
+++ b/lib/ingest/runner.ts
@@ -1,0 +1,95 @@
+import { Queue, Worker, QueueScheduler, JobsOptions } from "bullmq";
+import { URL } from "node:url";
+import { LeadStatus } from "@prisma/client";
+import { STARTER_ALLOWLIST } from "./allowlist";
+import { searchGoogleCse } from "./sources/googleCSE";
+import { normalizeLeadFromSnippet } from "./normalize";
+import { upsertLead } from "../db/leads";
+
+const connection = process.env.REDIS_URL
+  ? new URL(process.env.REDIS_URL)
+  : null;
+
+const queueName = "ingestion:run";
+
+let queue: Queue | null = null;
+let scheduler: QueueScheduler | null = null;
+let worker: Worker | null = null;
+
+function createConnectionConfig() {
+  if (!connection) return undefined;
+  return {
+    connection: {
+      host: connection.hostname,
+      port: Number(connection.port || 6379),
+      password: connection.password || undefined,
+    },
+  };
+}
+
+async function fetchRobotsTxt(domain: string): Promise<boolean> {
+  try {
+    const url = new URL(`https://${domain}`);
+    url.pathname = "/robots.txt";
+    const res = await fetch(url, { method: "GET" });
+    if (!res.ok) return true;
+    const body = await res.text();
+    if (/disallow:\s*\//i.test(body) && /user-agent:\s*\*/i.test(body)) {
+      return false;
+    }
+    return true;
+  } catch (error) {
+    console.warn(`robots.txt fetch failed for ${domain}`, error);
+    return false;
+  }
+}
+
+async function runJob(): Promise<void> {
+  for (const entry of STARTER_ALLOWLIST) {
+    if (!entry.enabled) continue;
+    const canCrawl = await fetchRobotsTxt(entry.domain);
+    if (!canCrawl) {
+      continue;
+    }
+    const query = `site:${entry.domain} comedy open mic signup`;
+    const { results } = await searchGoogleCse({ entry, query });
+    for (const result of results) {
+      const normalized = normalizeLeadFromSnippet(result.snippet);
+      await upsertLead({
+        source: entry.domain,
+        url: result.url,
+        title: result.title,
+        raw: result,
+        normalized: { ...normalized, externalUrl: result.url },
+        status: LeadStatus.REVIEW,
+      });
+    }
+  }
+}
+
+export async function ensureIngestionQueue(): Promise<void> {
+  if (!connection) {
+    if (process.env.NODE_ENV !== "production") {
+      console.log("Redis not configured; ingestion queue disabled");
+    }
+    return;
+  }
+  if (!queue) {
+    const config = createConnectionConfig();
+    queue = new Queue(queueName, config);
+    scheduler = new QueueScheduler(queueName, config);
+    worker = new Worker(queueName, runJob, config);
+    const repeat: JobsOptions["repeat"] = {
+      every: 10 * 60 * 1000,
+    };
+    await queue.add(queueName, {}, { repeat, removeOnComplete: true, removeOnFail: true });
+  }
+}
+
+export async function runIngestionNow(): Promise<void> {
+  if (queue) {
+    await queue.add(queueName, {}, { removeOnComplete: true, removeOnFail: true });
+    return;
+  }
+  await runJob();
+}

--- a/lib/ingest/sources/googleCSE.ts
+++ b/lib/ingest/sources/googleCSE.ts
@@ -1,0 +1,69 @@
+import crypto from "node:crypto";
+import { URL } from "node:url";
+import type { AllowlistEntry } from "../allowlist";
+
+export interface GoogleCseResult {
+  url: string;
+  title?: string;
+  snippet?: string;
+}
+
+export interface GoogleCseSearchParams {
+  entry: AllowlistEntry;
+  query: string;
+  geoContext?: string;
+}
+
+export interface GoogleCseSearchResult {
+  results: GoogleCseResult[];
+  nextPage?: string;
+}
+
+const GOOGLE_ENDPOINT = "https://www.googleapis.com/customsearch/v1";
+
+function buildQuery(entry: AllowlistEntry, geoContext?: string): string {
+  const base = `site:${entry.domain} ("open mic" OR "comedy" OR "standup") (signup OR "sign up" OR "booked show" OR "open mic")`;
+  return geoContext ? `${base} ${geoContext}` : base;
+}
+
+export async function searchGoogleCse({ entry, query, geoContext }: GoogleCseSearchParams): Promise<GoogleCseSearchResult> {
+  const apiKey = process.env.GOOGLE_CSE_KEY;
+  const cx = process.env.GOOGLE_CSE_ID;
+  if (!apiKey || !cx) {
+    return { results: [] };
+  }
+  const url = new URL(GOOGLE_ENDPOINT);
+  url.searchParams.set("key", apiKey);
+  url.searchParams.set("cx", cx);
+  url.searchParams.set("q", query || buildQuery(entry, geoContext));
+  url.searchParams.set("num", "10");
+
+  const response = await fetch(url, {
+    headers: {
+      "User-Agent": "TheFunnyLeadFetcher/1.0 (+https://thefunny.app)",
+    },
+  });
+  if (!response.ok) {
+    const body = await response.text();
+    console.error(`Google CSE error ${response.status}: ${body}`);
+    return { results: [] };
+  }
+  const data = (await response.json()) as {
+    items?: Array<{ link: string; title?: string; snippet?: string }>;
+    queries?: { nextPage?: Array<{ startIndex: number }> };
+  };
+  const results: GoogleCseResult[] = (data.items ?? []).map((item) => ({
+    url: item.link,
+    title: item.title,
+    snippet: item.snippet,
+  }));
+  const nextPageIndex = data.queries?.nextPage?.[0]?.startIndex;
+  return {
+    results,
+    nextPage: nextPageIndex ? `${url.toString()}&start=${nextPageIndex}` : undefined,
+  };
+}
+
+export function hashResult(result: GoogleCseResult): string {
+  return crypto.createHash("sha1").update(result.url).digest("hex");
+}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,10 @@
     "lint": "next lint",
     "test": "vitest",
     "openmics:once": "tsx -r dotenv/config -e \"import('./lib/openmics/ingest').then(m=>m.runOpenMicIngestion())\"",
-    "openmics:cron": "node --loader tsx scripts/openmic-cron.ts"
+    "openmics:cron": "node --loader tsx scripts/openmic-cron.ts",
+    "db:generate": "prisma generate",
+    "db:migrate": "prisma migrate deploy",
+    "db:seed": "tsx scripts/migrate-json-to-postgres.ts"
   },
   "dependencies": {
     "@auth/prisma-adapter": "^1.0.7",
@@ -51,7 +54,16 @@
     "tailwindcss": "^3.4.1",
     "tailwindcss-animate": "^1.0.7",
     "ws": "^8.16.0",
-    "zod": "^3.22.4"
+    "zod": "^3.22.4",
+    "bullmq": "^4.17.0",
+    "ioredis": "^5.4.1",
+    "meilisearch": "^0.38.0",
+    "@sentry/nextjs": "^7.100.1",
+    "leaflet": "^1.9.4",
+    "react-leaflet": "^4.2.1",
+    "@mapbox/search-js-react": "^1.0.0",
+    "@react-email/components": "^0.0.15",
+    "date-fns": "^3.6.0"
   },
   "devDependencies": {
     "@types/bcryptjs": "^2.4.2",
@@ -69,6 +81,9 @@
     "prettier": "^3.2.4",
     "tsx": "^4.20.6",
     "typescript": "^5.3.3",
-    "vitest": "^1.2.0"
+    "vitest": "^1.2.0",
+    "@playwright/test": "^1.44.0",
+    "playwright": "^1.44.0",
+    "@types/leaflet": "^1.9.8"
   }
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,3 +1,5 @@
+// Prisma schema for The Funny production-ready MVP
+
 generator client {
   provider = "prisma-client-js"
 }
@@ -8,270 +10,252 @@ datasource db {
 }
 
 enum Role {
-  COMEDIAN
+  ADMIN
   PROMOTER
   VENUE
-  ADMIN
+  COMEDIAN
+  FAN
+}
+
+enum GigType {
+  OPEN_MIC
+  BOOKED_SHOW
+  PAID_GIG
+}
+
+enum LeadStatus {
+  NEW
+  REVIEW
+  APPROVED
+  REJECTED
+  DUPLICATE
+}
+
+enum GigStatus {
+  DRAFT
+  PENDING
+  PUBLISHED
+  ARCHIVED
+}
+
+enum SignUpMethod {
+  WALKUP
+  ONLINE_FORM
+  DM
+  EMAIL
+  OTHER
 }
 
 enum ApplicationStatus {
-  PENDING
-  REVIEWING
-  ACCEPTED
+  APPLIED
+  SHORTLISTED
   REJECTED
-  WITHDRAWN
+  BOOKED
+  CANCELLED
 }
 
-enum ReviewTargetType {
-  USER
-  GIG
+enum PayoutStatus {
+  NONE
+  HELD
+  PAID
+  REFUNDED
+}
+
+enum VerificationStatus {
+  PENDING
+  APPROVED
+  REJECTED
 }
 
 model User {
-  id                String                 @id @default(cuid())
-  name              String?
-  email             String?                @unique
-  emailVerified     DateTime?
-  image             String?
-  role              Role                   @default(COMEDIAN)
-  passwordHash      String?
-  createdAt         DateTime               @default(now())
-  updatedAt         DateTime               @updatedAt
-  accounts          Account[]
-  sessions          Session[]
-  comedianProfile   ComedianProfile?
-  venueProfile      VenueProfile?
-  promoterProfile   PromoterProfile?
-  gigs              Gig[]                  @relation("GigCreator")
-  applications      Application[]          @relation("ComedianApplications")
-  follows           Follow[]               @relation("UserFollowing")
-  followers         Follow[]               @relation("UserFollowers")
-  favorites         Favorite[]             @relation("UserFavorites")
-  favoriteOf        Favorite[]             @relation("TargetUserFavorites")
-  reviewsGiven      Review[]               @relation("ReviewsGiven")
-  reviewsReceived   Review[]               @relation("ReviewsReceived")
-  messageThreads    MessageThreadParticipant[]
-  messages          Message[]
+  id           String    @id @default(cuid())
+  email        String    @unique
+  passwordHash String
+  role         Role      @default(FAN)
+  createdAt    DateTime  @default(now())
+
+  profile              Profile?
+  ownedVenues          Venue[]       @relation("VenueOwner")
+  promoter             Promoter?
+  gigsCreated          Gig[]         @relation("GigPromoter")
+  applications         Application[] @relation("GigApplications")
+  bookings             Booking[]     @relation("GigBookings")
+  verificationRequests VerificationRequest[]
+  messagesSent         Message[]     @relation("MessageSender")
+  messagesReceived     Message[]     @relation("MessageRecipient")
+  reviewedRequests     VerificationRequest[] @relation("VerificationReviewer")
+  emailTokens          EmailVerificationToken[]
+
+  @@map("users")
 }
 
-model Account {
-  id                 String  @id @default(cuid())
-  userId             String
-  type               String
-  provider           String
-  providerAccountId  String
-  refresh_token      String? @map("refreshToken")
-  access_token       String? @map("accessToken")
-  expires_at         Int?    @map("expiresAt")
-  token_type         String? @map("tokenType")
-  scope              String?
-  id_token           String? @map("idToken")
-  session_state      String? @map("sessionState")
-  oauth_token_secret String? @map("oauthTokenSecret")
-  oauth_token        String? @map("oauthToken")
-  user               User    @relation(fields: [userId], references: [id], onDelete: Cascade)
+model Profile {
+  id        String  @id @default(cuid())
+  userId    String  @unique
+  stageName String?
+  bio       String?
+  avatarUrl String?
+  city      String?
+  region    String?
+  country   String?
+  links     Json?
+  user      User    @relation(fields: [userId], references: [id], onDelete: Cascade)
 
-  @@unique([provider, providerAccountId])
+  @@map("profiles")
 }
 
-model Session {
-  id           String   @id @default(cuid())
-  sessionToken String   @unique
-  userId       String
-  expires      DateTime
-  user         User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+model Venue {
+  id        String   @id @default(cuid())
+  ownerId   String
+  name      String
+  address   String?
+  lat       Float?
+  lng       Float?
+  phone     String?
+  website   String?
+  gigs      Gig[]
+  owner     User     @relation("VenueOwner", fields: [ownerId], references: [id], onDelete: Cascade)
+
+  @@map("venues")
 }
 
-model VerificationToken {
-  identifier String
-  token      String   @unique
-  expires    DateTime
+model Promoter {
+  id      String @id @default(cuid())
+  userId  String @unique
+  orgName String?
+  website String?
+  user    User   @relation(fields: [userId], references: [id], onDelete: Cascade)
+  gigs    Gig[]
 
-  @@unique([identifier, token])
-}
-
-model ComedianProfile {
-  id          String   @id @default(cuid())
-  userId      String   @unique
-  stageName   String?
-  bio         String?
-  styles      Json     @default("[]")
-  socials     Json     @default("{}")
-  location    Json     @default("{}")
-  reelUrl     String?
-  media       Json     @default("[]")
-  rating      Float    @default(0)
-  ratingCount Int      @default(0)
-  user        User     @relation(fields: [userId], references: [id], onDelete: Cascade)
-  // Ratings are derived from related reviews on the owning user
-}
-
-model VenueProfile {
-  id          String   @id @default(cuid())
-  userId      String   @unique
-  name        String?
-  bio         String?
-  socials     Json     @default("{}")
-  location    Json     @default("{}")
-  media       Json     @default("[]")
-  capacity    Int?
-  amenities   Json     @default("[]")
-  rating      Float    @default(0)
-  ratingCount Int      @default(0)
-  user        User     @relation(fields: [userId], references: [id], onDelete: Cascade)
-  // Ratings are derived from related reviews on the owning user
-}
-
-model PromoterProfile {
-  id          String   @id @default(cuid())
-  userId      String   @unique
-  organization String?
-  bio         String?
-  socials     Json     @default("{}")
-  location    Json     @default("{}")
-  media       Json     @default("[]")
-  rating      Float    @default(0)
-  ratingCount Int      @default(0)
-  user        User     @relation(fields: [userId], references: [id], onDelete: Cascade)
-  // Ratings are derived from related reviews on the owning user
+  @@map("promoters")
 }
 
 model Gig {
-  id              String        @id @default(cuid())
-  title           String
-  description     String
-  styles          Json          @default("[]")
-  city            String
-  state           String
-  payout          Decimal       @db.Decimal(10, 2)
-  setLengthMin    Int           @default(15)
-  ageRestriction  Int?
-  dateStart       DateTime
-  dateEnd         DateTime?
-  published       Boolean       @default(false)
-  createdAt       DateTime       @default(now())
-  updatedAt       DateTime       @updatedAt
-  createdByUserId String
-  createdBy       User          @relation("GigCreator", fields: [createdByUserId], references: [id], onDelete: Cascade)
-  applications    Application[]
-  favorites       Favorite[]
+  id             String    @id @default(cuid())
+  type           GigType   @default(OPEN_MIC)
+  title          String
+  description    String
+  venueId        String?
+  promoterId     String?
+  startsAt       DateTime
+  endsAt         DateTime?
+  isRecurring    Boolean   @default(false)
+  recurrenceRule String?
+  payMin         Int?
+  payMax         Int?
+  bringer        Boolean   @default(false)
+  signUpMethod   SignUpMethod @default(WALKUP)
+  externalUrl    String?
+  status         GigStatus @default(DRAFT)
+  createdAt      DateTime  @default(now())
+  updatedAt      DateTime  @updatedAt
+
+  venue          Venue?    @relation(fields: [venueId], references: [id])
+  promoter       Promoter? @relation(fields: [promoterId], references: [id])
+  applications   Application[]
+  bookings       Booking[]
+  leads          Lead[]
+
+  @@map("gigs")
+  @@index([status])
+  @@index([type, status])
 }
 
 model Application {
-  id            String             @id @default(cuid())
-  gigId         String
-  comedianId    String
-  status        ApplicationStatus  @default(PENDING)
-  createdAt     DateTime           @default(now())
-  updatedAt     DateTime           @updatedAt
-  gig           Gig                @relation(fields: [gigId], references: [id], onDelete: Cascade)
-  comedian      User               @relation("ComedianApplications", fields: [comedianId], references: [id], onDelete: Cascade)
+  id          String            @id @default(cuid())
+  gigId       String
+  comedianId  String
+  status      ApplicationStatus @default(APPLIED)
+  notes       String?
+  createdAt   DateTime          @default(now())
 
-  @@unique([gigId, comedianId])
+  gig         Gig               @relation(fields: [gigId], references: [id], onDelete: Cascade)
+  comedian    User              @relation("GigApplications", fields: [comedianId], references: [id], onDelete: Cascade)
+
+  @@map("applications")
+  @@index([gigId, comedianId])
 }
 
-model Follow {
-  followerId String
-  followingId String
-  createdAt DateTime @default(now())
-  follower  User     @relation("UserFollowing", fields: [followerId], references: [id], onDelete: Cascade)
-  following User     @relation("UserFollowers", fields: [followingId], references: [id], onDelete: Cascade)
+model Booking {
+  id           String       @id @default(cuid())
+  gigId        String
+  comedianId   String
+  amountCents  Int?
+  currency     String?      @default("usd")
+  payoutStatus PayoutStatus @default(NONE)
 
-  @@id([followerId, followingId])
+  gig          Gig          @relation(fields: [gigId], references: [id], onDelete: Cascade)
+  comedian     User         @relation("GigBookings", fields: [comedianId], references: [id], onDelete: Cascade)
+
+  @@map("bookings")
 }
 
-model Favorite {
-  id            String   @id @default(cuid())
-  userId        String
-  gigId         String?
-  targetUserId  String?
-  createdAt     DateTime @default(now())
-  user          User     @relation("UserFavorites", fields: [userId], references: [id], onDelete: Cascade)
-  gig           Gig?     @relation(fields: [gigId], references: [id], onDelete: Cascade)
-  targetUser    User?    @relation("TargetUserFavorites", fields: [targetUserId], references: [id], onDelete: Cascade)
+model VerificationRequest {
+  id          String             @id @default(cuid())
+  userId      String
+  docUrl      String?
+  note        String?
+  status      VerificationStatus @default(PENDING)
+  reviewedBy  String?
+  reviewedAt  DateTime?
 
-  @@index([userId])
-  @@index([gigId])
-  @@index([targetUserId])
-}
+  user        User               @relation(fields: [userId], references: [id], onDelete: Cascade)
+  reviewer    User?              @relation("VerificationReviewer", fields: [reviewedBy], references: [id])
 
-model Review {
-  id              String           @id @default(cuid())
-  targetUserId    String
-  targetType      ReviewTargetType @default(USER)
-  rating          Int
-  comment         String?
-  createdByUserId String
-  createdAt       DateTime         @default(now())
-  updatedAt       DateTime         @updatedAt
-  targetUser      User             @relation("ReviewsReceived", fields: [targetUserId], references: [id], onDelete: Cascade)
-  createdBy       User             @relation("ReviewsGiven", fields: [createdByUserId], references: [id], onDelete: Cascade)
-}
-
-model MessageThread {
-  id            String                        @id @default(cuid())
-  createdAt     DateTime                      @default(now())
-  updatedAt     DateTime                      @updatedAt
-  participants  MessageThreadParticipant[]
-  messages      Message[]
-}
-
-model MessageThreadParticipant {
-  id        String        @id @default(cuid())
-  threadId  String
-  userId    String
-  thread    MessageThread @relation(fields: [threadId], references: [id], onDelete: Cascade)
-  user      User          @relation(fields: [userId], references: [id], onDelete: Cascade)
-
-  @@unique([threadId, userId])
+  @@map("verification_requests")
 }
 
 model Message {
-  id        String   @id @default(cuid())
-  threadId  String
-  senderId  String
-  body      String
-  createdAt DateTime @default(now())
-  thread    MessageThread @relation(fields: [threadId], references: [id], onDelete: Cascade)
-  sender    User      @relation(fields: [senderId], references: [id], onDelete: Cascade)
+  id           String   @id @default(cuid())
+  threadId     String
+  senderId     String
+  recipientId  String
+  body         String
+  createdAt    DateTime @default(now())
+
+  sender       User     @relation("MessageSender", fields: [senderId], references: [id], onDelete: Cascade)
+  recipient    User     @relation("MessageRecipient", fields: [recipientId], references: [id], onDelete: Cascade)
+
+  @@map("messages")
+  @@index([threadId])
 }
 
-model OpenMic {
-  id          String   @id @default(cuid())
+model Lead {
+  id          String     @id @default(cuid())
   source      String
-  sourceId    String?
-  title       String
-  description String?
   url         String
-  signupUrl   String?
-  dayOfWeek   Int?
-  startUtc    DateTime?
-  endUtc      DateTime?
-  recurrence  String?
-  venueName   String?
-  address     String?
-  city        String?
-  state       String?
-  country     String?  @default("US")
-  lat         Float?
-  lng         Float?
-  isFree      Boolean? @default(true)
-  tags        String[]
-  imageUrl    String?
-  scrapedHash String?
-  status      String   @default("published")
-  createdAt   DateTime @default(now())
-  updatedAt   DateTime @updatedAt
+  title       String?
+  raw         Json?
+  normalized  Json?
+  seenHash    String?
+  status      LeadStatus @default(NEW)
+  gigId       String?
+  createdAt   DateTime   @default(now())
+  updatedAt   DateTime   @updatedAt
 
-  @@unique([source, sourceId])
-  @@index([city, state, dayOfWeek])
-  @@index([startUtc, city, state])
+  gig         Gig?       @relation(fields: [gigId], references: [id])
+
+  @@unique([url])
+  @@map("leads")
 }
 
-model IngestLog {
+model AllowlistSource {
+  id            String  @id @default(cuid())
+  domain        String  @unique
+  label         String
+  enabled       Boolean @default(true)
+  lastCheckedAt DateTime?
+
+  @@map("allowlist_sources")
+}
+
+model EmailVerificationToken {
   id        String   @id @default(cuid())
-  source    String
-  succeeded Boolean
-  message   String?
-  createdAt DateTime @default(now())
+  userId    String
+  token     String   @unique
+  expiresAt DateTime
+
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@map("email_verification_tokens")
 }


### PR DESCRIPTION
## Summary
- replace the Prisma schema with The Funny production models for users, gigs, leads, allowlist sources, and supporting enums
- scaffold database access helpers that fall back to the legacy JSON datastore when DATABASE_URL is not provided
- introduce an allowlisted ingestion pipeline stub with Google Custom Search integration and BullMQ scheduling groundwork

## Testing
- not run (infrastructure scaffold only)

------
https://chatgpt.com/codex/tasks/task_e_68e1b5cad9ac8323a74c25b84f52ae0d