### PR TITLE
Fix Prisma client fallback in JSON datastore mode

### DIFF
--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -29,7 +29,6 @@ import {
   updateVenueProfile,
   deleteGig
 } from "@/lib/dataStore";
-import { PrismaClient } from "@prisma/client";
 import type {
   Application,
   ComedianAppearance,
@@ -235,11 +234,6 @@ async function hydrateComedianProfile(
     result.appearances = appearances;
   }
   return result;
-}
-
-const prismaClient: PrismaClient & { __patched?: true } = (globalThis as any).__prismaClient ?? new PrismaClient();
-if (process.env.NODE_ENV !== "production") {
-  (globalThis as any).__prismaClient = prismaClient;
 }
 
 export const prisma = {


### PR DESCRIPTION
## Summary
- remove the direct PrismaClient instantiation from the JSON datastore shim so the app no longer requires prisma generate in development

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e1bd9726288323a5d38a9f22c74a96