### PR TITLE
feat: support heroicons in shared icon component

### DIFF
--- a/app/comedians/page.tsx
+++ b/app/comedians/page.tsx
@@ -84,7 +84,7 @@ export default async function ComediansPage() {
                 </div>
                 {location && (
                   <p className="flex items-center gap-1 text-xs text-slate-500">
-                    <Icon name="MapPin" className="h-3.5 w-3.5 text-brand" />
+                    <Icon name="MapPinIcon" set="hero-outline" className="h-3.5 w-3.5 text-brand" />
                     {location}
                     {comedian.travelRadiusMiles ? ` • Travels ${comedian.travelRadiusMiles} mi` : null}
                   </p>
@@ -133,7 +133,7 @@ export default async function ComediansPage() {
                           >
                             <span className="inline-flex h-7 w-7 items-center justify-center rounded-full bg-brand/10 text-brand">
                               {video.platform === "YOUTUBE" ? (
-                                <Icon name="Play" className="h-3.5 w-3.5" />
+                                <Icon name="PlayCircleIcon" set="hero-solid" className="h-3.5 w-3.5" />
                               ) : (
                                 <Icon name="Video" className="h-3.5 w-3.5" />
                               )}

--- a/components/ui/Icon.tsx
+++ b/components/ui/Icon.tsx
@@ -2,18 +2,43 @@
 
 import { type ComponentProps, type ComponentType } from "react";
 import * as Lucide from "lucide-react";
+import * as HeroOutline from "@heroicons/react/24/outline";
+import * as HeroSolid from "@heroicons/react/24/solid";
 import { Star, MapPin, ChatsCircle } from "phosphor-react";
 
-type IconSet = "lucide" | "phosphor";
+type IconSet = "lucide" | "hero-outline" | "hero-solid" | "phosphor";
 
-type IconName = keyof typeof Lucide | "Star" | "MapPin" | "ChatsCircle";
+type LucideModule = typeof Lucide;
+type HeroOutlineModule = typeof HeroOutline;
+type HeroSolidModule = typeof HeroSolid;
+
+const lucideIcons = Lucide as Record<string, ComponentType<ComponentProps<"svg">>>;
+const heroOutlineIcons = HeroOutline as Record<string, ComponentType<ComponentProps<"svg">>>;
+const heroSolidIcons = HeroSolid as Record<string, ComponentType<ComponentProps<"svg">>>;
+const phosphorIcons = { Star, MapPin, ChatsCircle } satisfies Record<string, ComponentType<ComponentProps<"svg">>>;
+
+type IconName =
+  | keyof LucideModule
+  | keyof HeroOutlineModule
+  | keyof HeroSolidModule
+  | keyof typeof phosphorIcons;
+
+const FALLBACKS: Record<IconSet, ComponentType<ComponentProps<"svg">>> = {
+  lucide: Lucide.HelpCircle,
+  "hero-outline": HeroOutline.QuestionMarkCircleIcon,
+  "hero-solid": HeroSolid.QuestionMarkCircleIcon,
+  phosphor: Star,
+};
+
+const ICON_MAP: Record<IconSet, Record<string, ComponentType<ComponentProps<"svg">>>> = {
+  lucide: lucideIcons,
+  "hero-outline": heroOutlineIcons,
+  "hero-solid": heroSolidIcons,
+  phosphor: phosphorIcons,
+};
 
 export function Icon({ name, set = "lucide", ...props }: { name: IconName; set?: IconSet } & ComponentProps<"svg">) {
-  if (set === "lucide") {
-    const Cmp = (Lucide as Record<string, ComponentType<ComponentProps<"svg">>>)[name as string] ?? Lucide.HelpCircle;
-    return <Cmp aria-hidden {...props} />;
-  }
-  const map: Record<string, any> = { Star, MapPin, ChatsCircle };
-  const Cmp = map[name as string] ?? Star;
+  const icons = ICON_MAP[set];
+  const Cmp = icons[name as string] ?? FALLBACKS[set];
   return <Cmp aria-hidden {...props} />;
 }


### PR DESCRIPTION
## Summary
- extend the reusable Icon component to serve icons from lucide, Heroicons outline, and Heroicons solid sets
- demonstrate the new Heroicons support in the comedians directory cards

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e1c948de20832389e3e7b3f44eec45