### PR TITLE
chore(security): enforce validation, RBAC, and rate limits across messaging & admin tools

### DIFF
--- a/app/api/offers/[id]/route.ts
+++ b/app/api/offers/[id]/route.ts
@@ -33,17 +33,78 @@ export async function PATCH(
     return NextResponse.json({ error: "Thread not found" }, { status: 404 });
   }
 
-  if (
-    session.user.role !== Role.ADMIN &&
-    !thread.participantIds.includes(session.user.id)
-  ) {
+  const isAdmin = session.user.role === Role.ADMIN;
+  const isParticipant = thread.participantIds.includes(session.user.id);
+
+  if (!isAdmin && !isParticipant) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const isOfferSender = offer.fromUserId === session.user.id;
+  if (!isAdmin && isOfferSender) {
+    return NextResponse.json({ error: "Only the receiving comedian can update this offer" }, { status: 403 });
+  }
+
+  if (!isAdmin && session.user.role !== Role.COMEDIAN) {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 
   const json = await request.json();
-  const parsed = offerStatusSchema.safeParse(json);
+  const normalizedPayload: Record<string, unknown> = { ...json };
+  if (normalizedPayload.status === "ACCEPTED") {
+    normalizedPayload.gigId ??= thread.gigId;
+    if (!isAdmin) {
+      normalizedPayload.comedianId ??= session.user.id;
+    }
+    normalizedPayload.promoterId ??= offer.fromUserId;
+  }
+
+  const parsed = offerStatusSchema.safeParse(normalizedPayload);
   if (!parsed.success) {
     return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 });
+  }
+
+  if (!isAdmin) {
+    if (!["ACCEPTED", "DECLINED"].includes(parsed.data.status)) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    if (parsed.data.comedianId && parsed.data.comedianId !== session.user.id) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    if (
+      parsed.data.status === "ACCEPTED" &&
+      parsed.data.promoterId &&
+      parsed.data.promoterId !== offer.fromUserId
+    ) {
+      return NextResponse.json({ error: "Invalid promoter for offer" }, { status: 400 });
+    }
+  }
+
+  if (
+    parsed.data.status === "ACCEPTED" &&
+    parsed.data.gigId &&
+    parsed.data.gigId !== thread.gigId
+  ) {
+    return NextResponse.json({ error: "gigId must match the thread's gig" }, { status: 400 });
+  }
+
+  if (
+    parsed.data.status === "ACCEPTED" &&
+    parsed.data.comedianId &&
+    !thread.participantIds.includes(parsed.data.comedianId)
+  ) {
+    return NextResponse.json({ error: "Comedian is not part of this thread" }, { status: 403 });
+  }
+
+  if (
+    parsed.data.status === "ACCEPTED" &&
+    parsed.data.promoterId &&
+    !thread.participantIds.includes(parsed.data.promoterId) &&
+    parsed.data.promoterId !== offer.fromUserId
+  ) {
+    return NextResponse.json({ error: "Promoter is not part of this thread" }, { status: 403 });
   }
 
   const updatedOffer = await updateOfferStatus(offer.id, parsed.data.status);

--- a/app/api/threads/[id]/messages/route.ts
+++ b/app/api/threads/[id]/messages/route.ts
@@ -1,5 +1,4 @@
 import { NextResponse } from "next/server";
-import { z } from "zod";
 import { auth } from "@/lib/auth";
 import {
   createMessage,
@@ -10,30 +9,7 @@ import {
   markThreadState
 } from "@/lib/dataStore";
 import { rateLimit } from "@/lib/rateLimit";
-
-const messageSchema = z.discriminatedUnion("kind", [
-  z.object({
-    kind: z.literal("TEXT"),
-    body: z.string().min(1),
-    fileUrl: z.string().url().optional()
-  }),
-  z.object({
-    kind: z.literal("FILE"),
-    body: z.string().optional(),
-    fileUrl: z.string().url()
-  }),
-  z.object({
-    kind: z.literal("OFFER"),
-    body: z.string().optional(),
-    offer: z.object({
-      amount: z.number().int().min(1),
-      currency: z.string().default("USD"),
-      terms: z.string().min(5),
-      eventDate: z.string().datetime(),
-      expiresAt: z.string().datetime().optional()
-    })
-  })
-]);
+import { threadMessageSchema } from "@/lib/zodSchemas";
 
 export async function GET(_: Request, { params }: { params: { id: string } }) {
   const session = await auth();
@@ -74,7 +50,7 @@ export async function POST(request: Request, { params }: { params: { id: string 
   }
 
   const json = await request.json();
-  const parsed = messageSchema.safeParse(json);
+  const parsed = threadMessageSchema.safeParse(json);
   if (!parsed.success) {
     return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 });
   }


### PR DESCRIPTION
## Summary
- centralize schemas for offers, bookings, reviews, thread messages, ad slots, and admin toggles in `lib/zodSchemas`
- harden offer status updates so only the recipient comedian or admins can accept/decline and ensure booking metadata matches the thread
- add review rate limiting plus rate limits and schema validation for admin ad slot and flag/premium toggles

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e75927b5948323bb472ee8e6568861