### PR TITLE
Add coverage for offers, bookings, reviews, and search flows

### DIFF
--- a/tests/bookings.test.ts
+++ b/tests/bookings.test.ts
@@ -1,0 +1,156 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Role } from "@/lib/prismaEnums";
+
+const authMock = vi.fn();
+const rateLimitMock = vi.fn();
+const createBookingMock = vi.fn();
+const listBookingsForComedianMock = vi.fn();
+const listBookingsForPromoterMock = vi.fn();
+const getBookingByIdMock = vi.fn();
+const updateBookingMock = vi.fn();
+
+vi.mock("@/lib/auth", () => ({
+  auth: authMock,
+}));
+
+vi.mock("@/lib/rateLimit", () => ({
+  rateLimit: rateLimitMock,
+}));
+
+vi.mock("@/lib/dataStore", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/dataStore")>();
+  return {
+    ...actual,
+    createBooking: createBookingMock,
+    listBookingsForComedian: listBookingsForComedianMock,
+    listBookingsForPromoter: listBookingsForPromoterMock,
+    getBookingById: getBookingByIdMock,
+    updateBooking: updateBookingMock,
+  };
+});
+
+describe("bookings API", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    rateLimitMock.mockReturnValue(true);
+  });
+
+  it("allows promoters to create bookings for themselves", async () => {
+    const { POST: createBookingRoute } = await import("@/app/api/bookings/route");
+
+    authMock.mockResolvedValue({
+      user: { id: "promoter-1", role: Role.PROMOTER },
+    });
+    createBookingMock.mockResolvedValue({
+      id: "booking-1",
+      gigId: "gig-1",
+      comedianId: "comedian-1",
+      promoterId: "promoter-1",
+      offerId: "offer-1",
+      status: "PENDING",
+      payoutProtection: true,
+      cancellationPolicy: "STANDARD",
+      paymentIntentId: null,
+      createdAt: new Date("2024-01-05T00:00:00.000Z"),
+    });
+
+    const response = await createBookingRoute(
+      new Request("https://example.com/api/bookings", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          gigId: "gig-1",
+          comedianId: "comedian-1",
+          promoterId: "promoter-1",
+          offerId: "offer-1",
+        }),
+      })
+    );
+
+    expect(response.status).toBe(201);
+    expect(createBookingMock).toHaveBeenCalledWith({
+      gigId: "gig-1",
+      comedianId: "comedian-1",
+      promoterId: "promoter-1",
+      offerId: "offer-1",
+    });
+  });
+
+  it("lets booking participants update the status", async () => {
+    const { PATCH: updateBookingRoute } = await import(
+      "@/app/api/bookings/[id]/route"
+    );
+
+    authMock.mockResolvedValue({
+      user: { id: "comedian-1", role: Role.COMEDIAN },
+    });
+    getBookingByIdMock.mockResolvedValue({
+      id: "booking-1",
+      gigId: "gig-1",
+      comedianId: "comedian-1",
+      promoterId: "promoter-1",
+      offerId: "offer-1",
+      status: "PENDING",
+      payoutProtection: true,
+      cancellationPolicy: "STANDARD",
+      paymentIntentId: null,
+      createdAt: new Date("2024-01-05T00:00:00.000Z"),
+    });
+    updateBookingMock.mockResolvedValue({
+      id: "booking-1",
+      gigId: "gig-1",
+      comedianId: "comedian-1",
+      promoterId: "promoter-1",
+      offerId: "offer-1",
+      status: "COMPLETED",
+      payoutProtection: true,
+      cancellationPolicy: "STANDARD",
+      paymentIntentId: null,
+      createdAt: new Date("2024-01-05T00:00:00.000Z"),
+    });
+
+    const response = await updateBookingRoute(
+      new Request("https://example.com/api/bookings/booking-1", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ status: "COMPLETED" }),
+      }),
+      { params: { id: "booking-1" } }
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(updateBookingMock).toHaveBeenCalledWith("booking-1", {
+      status: "COMPLETED",
+    });
+    expect(payload.booking.status).toBe("COMPLETED");
+  });
+
+  it("prevents unrelated users from reading a booking", async () => {
+    const { GET: getBookingRoute } = await import("@/app/api/bookings/[id]/route");
+
+    authMock.mockResolvedValue({
+      user: { id: "fan-1", role: Role.FAN },
+    });
+    getBookingByIdMock.mockResolvedValue({
+      id: "booking-1",
+      gigId: "gig-1",
+      comedianId: "comedian-2",
+      promoterId: "promoter-2",
+      offerId: "offer-1",
+      status: "PENDING",
+      payoutProtection: true,
+      cancellationPolicy: "STANDARD",
+      paymentIntentId: null,
+      createdAt: new Date("2024-01-05T00:00:00.000Z"),
+    });
+
+    const response = await getBookingRoute(
+      new Request("https://example.com/api/bookings/booking-1"),
+      { params: { id: "booking-1" } }
+    );
+
+    expect(response.status).toBe(403);
+    expect(listBookingsForComedianMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/offers.test.ts
+++ b/tests/offers.test.ts
@@ -1,0 +1,219 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Role } from "@/lib/prismaEnums";
+
+const authMock = vi.fn();
+const rateLimitMock = vi.fn();
+const createOfferMock = vi.fn();
+const getThreadByIdMock = vi.fn();
+const getOfferByIdMock = vi.fn();
+const updateOfferStatusMock = vi.fn();
+const createBookingMock = vi.fn();
+const getUserByIdMock = vi.fn();
+const markThreadStateMock = vi.fn();
+const createMessageMock = vi.fn();
+
+vi.mock("@/lib/auth", () => ({
+  auth: authMock,
+}));
+
+vi.mock("@/lib/rateLimit", () => ({
+  rateLimit: rateLimitMock,
+}));
+
+vi.mock("@/lib/dataStore", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/dataStore")>();
+  return {
+    ...actual,
+    COMMUNITY_BOARD_CATEGORIES: actual.COMMUNITY_BOARD_CATEGORIES,
+    createOffer: createOfferMock,
+    getThreadById: getThreadByIdMock,
+    getOfferById: getOfferByIdMock,
+    updateOfferStatus: updateOfferStatusMock,
+    createBooking: createBookingMock,
+    getUserById: getUserByIdMock,
+    markThreadState: markThreadStateMock,
+    createMessage: createMessageMock,
+  };
+});
+
+describe("offers API", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    rateLimitMock.mockReturnValue(true);
+  });
+
+  it("creates an offer when a promoter posts to a thread they participate in", async () => {
+    const eventDate = new Date("2024-02-01T19:00:00.000Z");
+    const { POST: createOfferRoute } = await import("@/app/api/offers/route");
+
+    authMock.mockResolvedValue({
+      user: { id: "promoter-1", role: Role.PROMOTER },
+    });
+    getThreadByIdMock.mockResolvedValue({
+      id: "thread-1",
+      gigId: "gig-1",
+      participantIds: ["promoter-1", "comedian-1"],
+    });
+    createOfferMock.mockResolvedValue({
+      id: "offer-1",
+      threadId: "thread-1",
+      fromUserId: "promoter-1",
+      amount: 500,
+      currency: "USD",
+      terms: "Clean show",
+      status: "PENDING",
+      eventDate,
+      expiresAt: null,
+      createdAt: new Date("2024-01-01T00:00:00.000Z"),
+    });
+
+    const request = new Request("https://example.com/api/offers", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        threadId: "thread-1",
+        amount: 500,
+        terms: "Clean show",
+        currency: "usd",
+        eventDateISO: eventDate.toISOString(),
+      }),
+    });
+
+    const response = await createOfferRoute(request);
+    const payload = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(createOfferMock).toHaveBeenCalledTimes(1);
+    const createArgs = createOfferMock.mock.calls[0][0];
+    expect(createArgs).toMatchObject({
+      threadId: "thread-1",
+      fromUserId: "promoter-1",
+      amount: 500,
+      currency: "USD",
+      terms: "Clean show",
+    });
+    expect(createArgs.eventDate).toBeInstanceOf(Date);
+    expect(payload.offer.id).toBe("offer-1");
+  });
+
+  it("accepts an offer and creates a booking for the participants", async () => {
+    const { POST: acceptOfferRoute } = await import(
+      "@/app/api/offers/[id]/accept/route"
+    );
+
+    authMock.mockResolvedValue({
+      user: { id: "comedian-1", role: Role.COMEDIAN },
+    });
+    getOfferByIdMock.mockResolvedValue({
+      id: "offer-1",
+      threadId: "thread-1",
+      fromUserId: "promoter-1",
+      status: "PENDING",
+    });
+    getThreadByIdMock.mockResolvedValue({
+      id: "thread-1",
+      gigId: "gig-1",
+      participantIds: ["promoter-1", "comedian-1"],
+    });
+    getUserByIdMock.mockImplementation(async (id: string) => {
+      if (id === "promoter-1") {
+        return { id, role: Role.PROMOTER };
+      }
+      return { id, role: Role.COMEDIAN };
+    });
+    updateOfferStatusMock.mockResolvedValue({ status: "ACCEPTED" });
+    createBookingMock.mockResolvedValue({
+      id: "booking-1",
+      gigId: "gig-1",
+      comedianId: "comedian-1",
+      promoterId: "promoter-1",
+      offerId: "offer-1",
+      status: "PENDING",
+      payoutProtection: true,
+      cancellationPolicy: "STANDARD",
+      paymentIntentId: null,
+      createdAt: new Date("2024-01-02T00:00:00.000Z"),
+    });
+    markThreadStateMock.mockResolvedValue(undefined);
+    createMessageMock.mockResolvedValue(undefined);
+
+    const response = await acceptOfferRoute(new Request("https://example.com"), {
+      params: { id: "offer-1" },
+    });
+    const payload = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(updateOfferStatusMock).toHaveBeenCalledWith("offer-1", "ACCEPTED");
+    expect(createBookingMock).toHaveBeenCalledWith({
+      gigId: "gig-1",
+      comedianId: "comedian-1",
+      promoterId: "promoter-1",
+      offerId: "offer-1",
+    });
+    expect(markThreadStateMock).toHaveBeenCalledWith("thread-1", "BOOKED");
+    expect(createMessageMock).toHaveBeenCalledWith({
+      threadId: "thread-1",
+      senderId: "comedian-1",
+      kind: "SYSTEM",
+      body: "Offer accepted. Booking created: booking-1",
+    });
+    expect(payload.booking.id).toBe("booking-1");
+  });
+
+  it("declines an offer and emits a system message", async () => {
+    const { POST: declineOfferRoute } = await import(
+      "@/app/api/offers/[id]/decline/route"
+    );
+
+    authMock.mockResolvedValue({
+      user: { id: "comedian-1", role: Role.COMEDIAN },
+    });
+    getOfferByIdMock.mockResolvedValue({
+      id: "offer-1",
+      threadId: "thread-1",
+      fromUserId: "promoter-1",
+      status: "PENDING",
+    });
+    getThreadByIdMock.mockResolvedValue({
+      id: "thread-1",
+      participantIds: ["promoter-1", "comedian-1"],
+    });
+
+    const response = await declineOfferRoute(new Request("https://example.com"), {
+      params: { id: "offer-1" },
+    });
+
+    expect(response.status).toBe(200);
+    expect(updateOfferStatusMock).toHaveBeenCalledWith("offer-1", "DECLINED");
+    expect(createMessageMock).toHaveBeenCalledWith({
+      threadId: "thread-1",
+      senderId: "comedian-1",
+      kind: "SYSTEM",
+      body: "Offer declined.",
+    });
+  });
+
+  it("rejects offer creation for unauthorized roles", async () => {
+    const { POST: createOfferRoute } = await import("@/app/api/offers/route");
+
+    authMock.mockResolvedValue({
+      user: { id: "fan-1", role: Role.FAN },
+    });
+
+    const response = await createOfferRoute(
+      new Request("https://example.com/api/offers", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          threadId: "thread-1",
+          amount: 100,
+          terms: "Offer",
+          eventDateISO: new Date().toISOString(),
+        }),
+      })
+    );
+
+    expect(response.status).toBe(403);
+    expect(createOfferMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/rbac.test.ts
+++ b/tests/rbac.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 import { Role, VerificationStatus } from "@/lib/prismaEnums";
-import { canApplyToGig, canPublishGig } from "@/lib/rbac";
+import {
+  canApplyToGig,
+  canPublishGig,
+  requiresVerification,
+  roleLabelMap,
+} from "@/lib/rbac";
 
 describe("RBAC helpers", () => {
   it("allows verified promoters to publish", () => {
@@ -17,5 +22,28 @@ describe("RBAC helpers", () => {
 
   it("blocks fans from applying", () => {
     expect(canApplyToGig(Role.FAN)).toBe(false);
+  });
+
+  it("requires verification for promoters and venues", () => {
+    expect(requiresVerification(Role.PROMOTER)).toBe(true);
+    expect(requiresVerification(Role.VENUE)).toBe(true);
+  });
+
+  it("does not require verification for comedians, fans, or admins", () => {
+    expect(requiresVerification(Role.COMEDIAN)).toBe(false);
+    expect(requiresVerification(Role.FAN)).toBe(false);
+    expect(requiresVerification(Role.ADMIN)).toBe(false);
+  });
+
+  it("allows admins to publish regardless of verification status", () => {
+    expect(canPublishGig(Role.ADMIN, null)).toBe(true);
+  });
+
+  it("maps every role to a human-readable label", () => {
+    expect(roleLabelMap[Role.COMEDIAN]).toBe("Comedian");
+    expect(roleLabelMap[Role.PROMOTER]).toBe("Promoter");
+    expect(roleLabelMap[Role.VENUE]).toBe("Venue");
+    expect(roleLabelMap[Role.FAN]).toBe("Fan");
+    expect(roleLabelMap[Role.ADMIN]).toBe("Admin");
   });
 });

--- a/tests/reviews.test.ts
+++ b/tests/reviews.test.ts
@@ -1,0 +1,171 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Role } from "@/lib/prismaEnums";
+
+const authMock = vi.fn();
+const rateLimitMock = vi.fn();
+const createReviewMock = vi.fn();
+const getGigByIdMock = vi.fn();
+const listBookingsForGigMock = vi.fn();
+const listReviewsForGigMock = vi.fn();
+const listReviewsForUserMock = vi.fn();
+
+vi.mock("@/lib/auth", () => ({
+  auth: authMock,
+}));
+
+vi.mock("@/lib/rateLimit", () => ({
+  rateLimit: rateLimitMock,
+}));
+
+vi.mock("@/lib/dataStore", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/dataStore")>();
+  return {
+    ...actual,
+    createReview: createReviewMock,
+    getGigById: getGigByIdMock,
+    listBookingsForGig: listBookingsForGigMock,
+    listReviewsForGig: listReviewsForGigMock,
+    listReviewsForUser: listReviewsForUserMock,
+  };
+});
+
+describe("reviews API", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    rateLimitMock.mockReturnValue(true);
+  });
+
+  it("lists reviews for a subject user", async () => {
+    const { GET: reviewsGetRoute } = await import("@/app/api/reviews/route");
+
+    listReviewsForUserMock.mockResolvedValue([
+      {
+        id: "review-1",
+        authorUserId: "promoter-1",
+        subjectUserId: "comedian-1",
+        gigId: "gig-1",
+        rating: 5,
+        comment: "Fantastic performance",
+        visible: true,
+        createdAt: new Date("2024-01-01T00:00:00.000Z"),
+      },
+    ]);
+
+    const response = await reviewsGetRoute(
+      new Request("https://example.com/api/reviews?subjectUserId=comedian-1")
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(listReviewsForUserMock).toHaveBeenCalledWith("comedian-1");
+    expect(payload.reviews).toHaveLength(1);
+    expect(payload.reviews[0]).toMatchObject({
+      id: "review-1",
+      authorUserId: "promoter-1",
+      createdAt: expect.any(String),
+    });
+  });
+
+  it("allows eligible participants to create a review", async () => {
+    const { POST: reviewsPostRoute } = await import("@/app/api/reviews/route");
+
+    authMock.mockResolvedValue({
+      user: { id: "promoter-1", role: Role.PROMOTER },
+    });
+    getGigByIdMock.mockResolvedValue({
+      id: "gig-1",
+      dateStart: new Date("2024-01-01T20:00:00.000Z"),
+    });
+    listBookingsForGigMock.mockResolvedValue([
+      {
+        id: "booking-1",
+        gigId: "gig-1",
+        comedianId: "comedian-1",
+        promoterId: "promoter-1",
+        offerId: "offer-1",
+        status: "COMPLETED",
+        payoutProtection: true,
+        cancellationPolicy: "STANDARD",
+        paymentIntentId: null,
+        createdAt: new Date("2023-12-01T00:00:00.000Z"),
+      },
+    ]);
+    listReviewsForGigMock.mockResolvedValue([]);
+    createReviewMock.mockResolvedValue({
+      id: "review-1",
+      authorUserId: "promoter-1",
+      subjectUserId: "comedian-1",
+      gigId: "gig-1",
+      rating: 5,
+      comment: "Great work",
+      visible: true,
+      createdAt: new Date("2024-01-02T00:00:00.000Z"),
+    });
+
+    const response = await reviewsPostRoute(
+      new Request("https://example.com/api/reviews", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          subjectUserId: "comedian-1",
+          gigId: "gig-1",
+          rating: 5,
+          comment: "Amazing comedian!",
+        }),
+      })
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(createReviewMock).toHaveBeenCalledWith({
+      authorUserId: "promoter-1",
+      subjectUserId: "comedian-1",
+      gigId: "gig-1",
+      rating: 5,
+      comment: "Amazing comedian!",
+    });
+    expect(payload.review).toMatchObject({ id: "review-1" });
+  });
+
+  it("blocks reviews when the booking is not completed", async () => {
+    const { POST: reviewsPostRoute } = await import("@/app/api/reviews/route");
+
+    authMock.mockResolvedValue({
+      user: { id: "promoter-1", role: Role.PROMOTER },
+    });
+    getGigByIdMock.mockResolvedValue({
+      id: "gig-1",
+      dateStart: new Date("2024-01-01T20:00:00.000Z"),
+    });
+    listBookingsForGigMock.mockResolvedValue([
+      {
+        id: "booking-1",
+        gigId: "gig-1",
+        comedianId: "comedian-1",
+        promoterId: "promoter-1",
+        offerId: "offer-1",
+        status: "PENDING",
+        payoutProtection: true,
+        cancellationPolicy: "STANDARD",
+        paymentIntentId: null,
+        createdAt: new Date("2023-12-01T00:00:00.000Z"),
+      },
+    ]);
+
+    const response = await reviewsPostRoute(
+      new Request("https://example.com/api/reviews", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          subjectUserId: "comedian-1",
+          gigId: "gig-1",
+          rating: 4,
+          comment: "Solid set overall",
+        }),
+      })
+    );
+
+    expect(response.status).toBe(403);
+    expect(createReviewMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/search.test.ts
+++ b/tests/search.test.ts
@@ -1,0 +1,345 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { DatabaseSnapshot } from "@/types/database";
+
+const DATA_DIR = path.join(process.cwd(), "data");
+const DATABASE_PATH = path.join(DATA_DIR, "database.json");
+
+const emptySnapshot = (): DatabaseSnapshot => ({
+  users: [],
+  comedianProfiles: [],
+  comedianVideos: [],
+  comedianAppearances: [],
+  promoterProfiles: [],
+  venueProfiles: [],
+  gigs: [],
+  applications: [],
+  verificationRequests: [],
+  favorites: [],
+  threads: [],
+  messages: [],
+  offers: [],
+  bookings: [],
+  conversationReviews: [],
+  reviews: [],
+  reviewReminders: [],
+  availability: [],
+  reports: [],
+  communityBoardMessages: [],
+  adSlots: [],
+  featureFlags: [],
+});
+
+async function seedDatabase(snapshot: DatabaseSnapshot) {
+  await fs.rm(DATA_DIR, { recursive: true, force: true });
+  await fs.mkdir(DATA_DIR, { recursive: true });
+  await fs.writeFile(DATABASE_PATH, JSON.stringify(snapshot, null, 2));
+  vi.resetModules();
+}
+
+describe("searchComedians", () => {
+  beforeEach(async () => {
+    await fs.rm(DATA_DIR, { recursive: true, force: true }).catch(() => undefined);
+    vi.resetModules();
+  });
+
+  it("applies filters for location, style, rate, and experience", async () => {
+    const now = new Date("2024-01-01T00:00:00.000Z");
+    const fiveYearsAgo = new Date("2019-01-01T00:00:00.000Z");
+    const twoYearsAgo = new Date("2022-01-01T00:00:00.000Z");
+
+    const snapshot = emptySnapshot();
+    snapshot.users = [
+      {
+        id: "comedian-premium",
+        name: "Zed Premium",
+        email: "zed@example.com",
+        hashedPassword: null,
+        role: "COMEDIAN",
+        createdAt: now.toISOString(),
+        isPremium: true,
+        premiumSince: now.toISOString(),
+      },
+      {
+        id: "comedian-basic",
+        name: "Aaron Basic",
+        email: "aaron@example.com",
+        hashedPassword: null,
+        role: "COMEDIAN",
+        createdAt: now.toISOString(),
+        isPremium: false,
+        premiumSince: null,
+      },
+      {
+        id: "comedian-remote",
+        name: "Remote Comic",
+        email: "remote@example.com",
+        hashedPassword: null,
+        role: "COMEDIAN",
+        createdAt: now.toISOString(),
+        isPremium: false,
+        premiumSince: null,
+      },
+    ];
+
+    snapshot.comedianProfiles = [
+      {
+        userId: "comedian-premium",
+        stageName: "Zed Premium",
+        bio: "Clean storyteller",
+        credits: null,
+        website: null,
+        reelUrl: null,
+        instagram: null,
+        tiktokHandle: null,
+        youtubeChannel: null,
+        travelRadiusMiles: 50,
+        homeCity: "New York",
+        homeState: "NY",
+        styles: ["Clean", "Storytelling"],
+        cleanRating: "CLEAN",
+        rateMin: 150,
+        rateMax: 300,
+        reelUrls: [],
+        photoUrls: [],
+        notableClubs: [],
+        availability: [],
+        createdAt: fiveYearsAgo.toISOString(),
+        updatedAt: now.toISOString(),
+      },
+      {
+        userId: "comedian-basic",
+        stageName: "Aaron Basic",
+        bio: "Edgy comic",
+        credits: null,
+        website: null,
+        reelUrl: null,
+        instagram: null,
+        tiktokHandle: null,
+        youtubeChannel: null,
+        travelRadiusMiles: 25,
+        homeCity: "Boston",
+        homeState: "MA",
+        styles: ["Dark", "Storytelling"],
+        cleanRating: "R",
+        rateMin: 50,
+        rateMax: 150,
+        reelUrls: [],
+        photoUrls: [],
+        notableClubs: [],
+        availability: [],
+        createdAt: twoYearsAgo.toISOString(),
+        updatedAt: now.toISOString(),
+      },
+      {
+        userId: "comedian-remote",
+        stageName: "Remote Comic",
+        bio: "Virtual shows only",
+        credits: null,
+        website: null,
+        reelUrl: null,
+        instagram: null,
+        tiktokHandle: null,
+        youtubeChannel: null,
+        travelRadiusMiles: 10,
+        homeCity: "Chicago",
+        homeState: "IL",
+        styles: ["Improv"],
+        cleanRating: "PG13",
+        rateMin: 80,
+        rateMax: 120,
+        reelUrls: [],
+        photoUrls: [],
+        notableClubs: [],
+        availability: [],
+        createdAt: now.toISOString(),
+        updatedAt: now.toISOString(),
+      },
+    ];
+
+    snapshot.comedianAppearances = [
+      {
+        id: "appearance-1",
+        comedianUserId: "comedian-premium",
+        showName: "Showcase",
+        venueName: "Big Club",
+        city: "New York",
+        state: "NY",
+        performedAt: fiveYearsAgo.toISOString(),
+        gigId: null,
+      },
+      {
+        id: "appearance-2",
+        comedianUserId: "comedian-basic",
+        showName: "Showcase",
+        venueName: "Club",
+        city: "Boston",
+        state: "MA",
+        performedAt: twoYearsAgo.toISOString(),
+        gigId: null,
+      },
+    ];
+
+    snapshot.reviews = [
+      {
+        id: "review-1",
+        authorUserId: "promoter-1",
+        subjectUserId: "comedian-premium",
+        gigId: "gig-1",
+        rating: 5,
+        comment: "Amazing",
+        visible: true,
+        createdAt: now.toISOString(),
+      },
+      {
+        id: "review-2",
+        authorUserId: "promoter-1",
+        subjectUserId: "comedian-basic",
+        gigId: "gig-2",
+        rating: 3,
+        comment: "Average",
+        visible: true,
+        createdAt: now.toISOString(),
+      },
+    ];
+
+    snapshot.featureFlags = [
+      { key: "premiumBoost", enabled: true, updatedAt: now.toISOString() },
+    ];
+
+    await seedDatabase(snapshot);
+    const { searchComedians } = await import("@/lib/dataStore");
+
+    const result = await searchComedians({
+      search: "premium",
+      city: "New",
+      state: "NY",
+      styles: ["Clean"],
+      rateMin: 100,
+      rateMax: 400,
+      minExperienceYears: 2,
+    });
+
+    expect(result.total).toBe(1);
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0].profile.userId).toBe("comedian-premium");
+  });
+
+  it("boosts premium comedians ahead of similar peers", async () => {
+    const now = new Date("2024-01-01T00:00:00.000Z");
+    const fiveYearsAgo = new Date("2019-01-01T00:00:00.000Z");
+
+    const snapshot = emptySnapshot();
+    snapshot.users = [
+      {
+        id: "premium-comic",
+        name: "Zed Premium",
+        email: "zed@example.com",
+        hashedPassword: null,
+        role: "COMEDIAN",
+        createdAt: now.toISOString(),
+        isPremium: true,
+        premiumSince: now.toISOString(),
+      },
+      {
+        id: "standard-comic",
+        name: "Aaron Standard",
+        email: "aaron@example.com",
+        hashedPassword: null,
+        role: "COMEDIAN",
+        createdAt: now.toISOString(),
+        isPremium: false,
+        premiumSince: null,
+      },
+    ];
+
+    snapshot.comedianProfiles = [
+      {
+        userId: "premium-comic",
+        stageName: "Zed Premium",
+        bio: null,
+        credits: null,
+        website: null,
+        reelUrl: null,
+        instagram: null,
+        tiktokHandle: null,
+        youtubeChannel: null,
+        travelRadiusMiles: 50,
+        homeCity: "New York",
+        homeState: "NY",
+        styles: ["Clean"],
+        cleanRating: "CLEAN",
+        rateMin: 200,
+        rateMax: 400,
+        reelUrls: [],
+        photoUrls: [],
+        notableClubs: [],
+        availability: [],
+        createdAt: fiveYearsAgo.toISOString(),
+        updatedAt: now.toISOString(),
+      },
+      {
+        userId: "standard-comic",
+        stageName: "Aaron Standard",
+        bio: null,
+        credits: null,
+        website: null,
+        reelUrl: null,
+        instagram: null,
+        tiktokHandle: null,
+        youtubeChannel: null,
+        travelRadiusMiles: 50,
+        homeCity: "New York",
+        homeState: "NY",
+        styles: ["Clean"],
+        cleanRating: "CLEAN",
+        rateMin: 200,
+        rateMax: 400,
+        reelUrls: [],
+        photoUrls: [],
+        notableClubs: [],
+        availability: [],
+        createdAt: fiveYearsAgo.toISOString(),
+        updatedAt: now.toISOString(),
+      },
+    ];
+
+    snapshot.reviews = [
+      {
+        id: "review-1",
+        authorUserId: "promoter-1",
+        subjectUserId: "premium-comic",
+        gigId: "gig-1",
+        rating: 5,
+        comment: "Great",
+        visible: true,
+        createdAt: now.toISOString(),
+      },
+      {
+        id: "review-2",
+        authorUserId: "promoter-1",
+        subjectUserId: "standard-comic",
+        gigId: "gig-2",
+        rating: 5,
+        comment: "Great",
+        visible: true,
+        createdAt: now.toISOString(),
+      },
+    ];
+
+    snapshot.featureFlags = [
+      { key: "premiumBoost", enabled: true, updatedAt: now.toISOString() },
+    ];
+
+    await seedDatabase(snapshot);
+    const { searchComedians } = await import("@/lib/dataStore");
+
+    const result = await searchComedians({ pageSize: 10 });
+
+    expect(result.items.map((item) => item.profile.stageName)).toEqual([
+      "Zed Premium",
+      "Aaron Standard",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- expand RBAC tests to cover verification requirements, admin publishing, and role labels
- add offers API tests for creation, accept/decline flows, and permission checks
- add bookings API tests covering creation, status updates, and participant authorization
- add reviews API tests for listing eligibility and review submission rules
- add search tests validating filters and premium boost ordering

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e75e82a5f8832398eaf875dae822c5