### PR TITLE
fix: keep free listings visible when boosting premium

### DIFF
--- a/lib/dataStore.ts
+++ b/lib/dataStore.ts
@@ -639,20 +639,18 @@ function applyPremiumBoost(items: ComedianSearchListItem[], enabled: boolean): C
     return items;
   }
 
-  const boosted = [...items];
-  for (let index = 1; index < boosted.length; index += 1) {
-    const current = boosted[index];
-    const previous = boosted[index - 1];
-    const currentPremium = current.user?.isPremium ?? false;
-    const previousPremium = previous.user?.isPremium ?? false;
+  const premium: ComedianSearchListItem[] = [];
+  const standard: ComedianSearchListItem[] = [];
 
-    if (currentPremium && !previousPremium) {
-      boosted[index - 1] = current;
-      boosted[index] = previous;
+  for (const item of items) {
+    if (item.user?.isPremium) {
+      premium.push(item);
+    } else {
+      standard.push(item);
     }
   }
 
-  return boosted;
+  return [...premium, ...standard];
 }
 
 export async function searchComedians(filters: ComedianSearchFilters = {}): Promise<ComedianSearchResult> {

--- a/tests/search.test.ts
+++ b/tests/search.test.ts
@@ -342,4 +342,94 @@ describe("searchComedians", () => {
       "Aaron Standard",
     ]);
   });
+
+  it("keeps free comedians visible while prioritising premium", async () => {
+    const now = new Date("2024-01-01T00:00:00.000Z");
+    const fiveYearsAgo = new Date("2019-01-01T00:00:00.000Z");
+
+    const snapshot = emptySnapshot();
+    snapshot.users = [
+      {
+        id: "free-first",
+        name: "Free One",
+        email: "free.one@example.com",
+        hashedPassword: null,
+        role: "COMEDIAN",
+        createdAt: now.toISOString(),
+        isPremium: false,
+        premiumSince: null,
+      },
+      {
+        id: "free-second",
+        name: "Free Two",
+        email: "free.two@example.com",
+        hashedPassword: null,
+        role: "COMEDIAN",
+        createdAt: now.toISOString(),
+        isPremium: false,
+        premiumSince: null,
+      },
+      {
+        id: "premium-middle",
+        name: "Premium Star",
+        email: "premium@example.com",
+        hashedPassword: null,
+        role: "COMEDIAN",
+        createdAt: now.toISOString(),
+        isPremium: true,
+        premiumSince: now.toISOString(),
+      },
+      {
+        id: "free-third",
+        name: "Free Three",
+        email: "free.three@example.com",
+        hashedPassword: null,
+        role: "COMEDIAN",
+        createdAt: now.toISOString(),
+        isPremium: false,
+        premiumSince: null,
+      },
+    ];
+
+    snapshot.comedianProfiles = snapshot.users.map((user) => ({
+      userId: user.id,
+      stageName: user.name ?? "Comic",
+      bio: null,
+      credits: null,
+      website: null,
+      reelUrl: null,
+      instagram: null,
+      tiktokHandle: null,
+      youtubeChannel: null,
+      travelRadiusMiles: 50,
+      homeCity: "Seattle",
+      homeState: "WA",
+      styles: ["Observational"],
+      cleanRating: "PG13",
+      rateMin: 100,
+      rateMax: 200,
+      reelUrls: [],
+      photoUrls: [],
+      notableClubs: [],
+      availability: [],
+      createdAt: fiveYearsAgo.toISOString(),
+      updatedAt: now.toISOString(),
+    }));
+
+    snapshot.featureFlags = [
+      { key: "premiumBoost", enabled: true, updatedAt: now.toISOString() },
+    ];
+
+    await seedDatabase(snapshot);
+    const { searchComedians } = await import("@/lib/dataStore");
+
+    const result = await searchComedians({ pageSize: 4 });
+
+    expect(result.items.map((item) => item.profile.stageName)).toEqual([
+      "Premium Star",
+      "Free One",
+      "Free Three",
+      "Free Two",
+    ]);
+  });
 });


### PR DESCRIPTION
## Summary
- ensure premium boost reorders search results without dropping standard listings
- add regression coverage verifying free comedians remain visible when the flag is active

## Testing
- npx vitest run tests/search.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e7663280808323ae0f3774c96ae6af