### PR TITLE
Replace next-themes with internal theme provider

### DIFF
--- a/components/providers/theme-provider.tsx
+++ b/components/providers/theme-provider.tsx
@@ -1,36 +1,109 @@
 "use client";
 
-import { ThemeProvider as NextThemesProvider, useTheme } from "next-themes";
-import { useEffect, type ReactNode } from "react";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode
+} from "react";
+
+type ThemeValue = "light" | "dark" | "system";
+
+type ThemeContextValue = {
+  theme: ThemeValue;
+  setTheme: (value: ThemeValue) => void;
+  resolvedTheme: "light" | "dark";
+};
+
+const STORAGE_KEY = "the-funny-theme";
+
+const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
 
 type ThemeProviderProps = {
   children: ReactNode;
 };
 
-function ThemeSync() {
-  const { theme, resolvedTheme } = useTheme();
+export function ThemeProvider({ children }: ThemeProviderProps) {
+  const [theme, setThemeState] = useState<ThemeValue>("system");
+  const [systemTheme, setSystemTheme] = useState<"light" | "dark">(() => {
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+      return "light";
+    }
+    return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+  });
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const stored = window.localStorage.getItem(STORAGE_KEY);
+    if (stored === "light" || stored === "dark" || stored === "system") {
+      setThemeState(stored);
+    }
+
+    if (typeof window.matchMedia !== "function") {
+      return;
+    }
+
+    const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
+    const listener = (event: MediaQueryListEvent) => {
+      setSystemTheme(event.matches ? "dark" : "light");
+    };
+
+    setSystemTheme(mediaQuery.matches ? "dark" : "light");
+
+    if (typeof mediaQuery.addEventListener === "function") {
+      mediaQuery.addEventListener("change", listener);
+      return () => {
+        mediaQuery.removeEventListener("change", listener);
+      };
+    }
+
+    mediaQuery.addListener(listener);
+    return () => {
+      mediaQuery.removeListener(listener);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    if (theme === "system") {
+      window.localStorage.removeItem(STORAGE_KEY);
+    } else {
+      window.localStorage.setItem(STORAGE_KEY, theme);
+    }
+  }, [theme]);
 
   useEffect(() => {
     if (typeof document === "undefined") return;
-
-    const activeTheme = (theme === "system" ? resolvedTheme : theme) ?? "light";
+    const activeTheme = theme === "system" ? systemTheme : theme;
     document.body.dataset.theme = activeTheme === "dark" ? "dark" : "thefunny";
-  }, [theme, resolvedTheme]);
+  }, [theme, systemTheme]);
 
-  return null;
+  const handleSetTheme = useCallback((value: ThemeValue) => {
+    setThemeState(value);
+  }, []);
+
+  const resolvedTheme: "light" | "dark" = theme === "system" ? systemTheme : theme;
+
+  const value = useMemo<ThemeContextValue>(
+    () => ({
+      theme,
+      setTheme: handleSetTheme,
+      resolvedTheme,
+    }),
+    [handleSetTheme, resolvedTheme, theme]
+  );
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
 }
 
-export function ThemeProvider({ children }: ThemeProviderProps) {
-  return (
-    <NextThemesProvider
-      attribute="class"
-      defaultTheme="system"
-      enableSystem
-      disableTransitionOnChange
-      value={{ light: "light", dark: "dark" }}
-    >
-      <ThemeSync />
-      {children}
-    </NextThemesProvider>
-  );
+export function useTheme() {
+  const context = useContext(ThemeContext);
+  if (!context) {
+    throw new Error("useTheme must be used within a ThemeProvider");
+  }
+  return context;
 }

--- a/components/ui/ThemeToggle.tsx
+++ b/components/ui/ThemeToggle.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useTheme } from "next-themes";
+import { useTheme } from "@/components/providers/theme-provider";
 import { Laptop2, MoonStar, SunMedium } from "lucide-react";
 import { useEffect, useMemo, useState, type ComponentType } from "react";
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,6 @@
         "dotenv": "^16.4.5",
         "lucide-react": "^0.322.0",
         "next": "14.1.0",
-        "next-themes": "^0.4.6",
         "node-cron": "^4.2.1",
         "nodemailer": "^6.9.8",
         "p-limit": "^7.1.1",
@@ -13126,16 +13125,6 @@
         "sass": {
           "optional": true
         }
-      }
-    },
-    "node_modules/next-themes": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
-      "integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/next/node_modules/nanoid": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "dotenv": "^16.4.5",
     "lucide-react": "^0.322.0",
     "next": "14.1.0",
-    "next-themes": "^0.4.6",
     "node-cron": "^4.2.1",
     "nodemailer": "^6.9.8",
     "p-limit": "^7.1.1",


### PR DESCRIPTION
## Summary
- implement an internal theme provider that syncs the selected mode with local storage and system preferences so the app no longer depends on the missing `next-themes` package
- update the theme toggle to consume the new provider and remove the unused `next-themes` dependency from the manifests

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e7eb68c96c83239e44426496f62e63