### PR TITLE
Fix dropdown hydration issues by updating CSP and dropdown menu

### DIFF
--- a/components/ui/ThemeToggle.tsx
+++ b/components/ui/ThemeToggle.tsx
@@ -4,7 +4,6 @@ import { useTheme } from "@/components/providers/theme-provider";
 import { Laptop2, MoonStar, SunMedium } from "lucide-react";
 import { useEffect, useMemo, useState, type ComponentType } from "react";
 
-import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -46,20 +45,15 @@ export function ThemeToggle({ className }: { className?: string }) {
 
   return (
     <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon"
-          className={cn(
-            "relative h-9 w-9 rounded-full border border-border/70 bg-background/80 shadow-sm backdrop-blur",
-            className
-          )}
-          aria-label="Toggle theme"
-        >
-          <ActiveIcon className="h-4 w-4" aria-hidden />
-          <span className="sr-only">Change theme</span>
-        </Button>
+      <DropdownMenuTrigger
+        className={cn(
+          "relative inline-flex h-9 w-9 items-center justify-center rounded-full border border-border/70 bg-background/80 shadow-sm backdrop-blur transition hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+          className
+        )}
+        aria-label="Toggle theme"
+      >
+        <ActiveIcon className="h-4 w-4" aria-hidden />
+        <span className="sr-only">Change theme</span>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" sideOffset={8} className="w-44">
         <DropdownMenuLabel className="text-xs uppercase tracking-[0.2em] text-muted-foreground">Theme</DropdownMenuLabel>

--- a/components/ui/dropdown-menu.tsx
+++ b/components/ui/dropdown-menu.tsx
@@ -1,170 +1,446 @@
 "use client";
 
-import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
-import { Check, ChevronRight } from "lucide-react";
-import * as React from "react";
+import {
+  cloneElement,
+  createContext,
+  forwardRef,
+  isValidElement,
+  useContext,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type ButtonHTMLAttributes,
+  type HTMLAttributes,
+  type KeyboardEventHandler,
+  type MutableRefObject,
+  type ReactElement,
+  type ReactNode,
+  type SpanHTMLAttributes,
+  type MouseEventHandler
+} from "react";
 
 import { cn } from "@/lib/utils";
 
-const DropdownMenu = DropdownMenuPrimitive.Root;
+type DropdownMenuContextValue = {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+  triggerRef: MutableRefObject<HTMLElement | null>;
+  menuRef: MutableRefObject<HTMLDivElement | null>;
+  menuId: string;
+  labelId?: string;
+  setLabelId: (id?: string) => void;
+};
 
-const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger;
+const DropdownMenuContext = createContext<DropdownMenuContextValue | null>(null);
 
-const DropdownMenuGroup = DropdownMenuPrimitive.Group;
-
-const DropdownMenuPortal = DropdownMenuPrimitive.Portal;
-
-const DropdownMenuSub = DropdownMenuPrimitive.Sub;
-
-const DropdownMenuRadioGroup = DropdownMenuPrimitive.RadioGroup;
-
-const DropdownMenuSubTrigger = React.forwardRef<
-  React.ElementRef<typeof DropdownMenuPrimitive.SubTrigger>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubTrigger> & {
-    inset?: boolean;
+function useDropdownMenuContext(component: string): DropdownMenuContextValue {
+  const context = useContext(DropdownMenuContext);
+  if (!context) {
+    throw new Error(`${component} must be used within a <DropdownMenu>`);
   }
->(({ className, inset, children, ...props }, ref) => (
-  <DropdownMenuPrimitive.SubTrigger
-    ref={ref}
-    className={cn(
-      "flex cursor-default select-none items-center rounded-md px-3 py-1.5 text-sm outline-none focus:bg-muted focus:text-foreground data-[state=open]:bg-muted",
-      inset && "pl-8",
-      className
-    )}
-    {...props}
-  >
-    {children}
-    <ChevronRight className="ml-auto h-4 w-4" />
-  </DropdownMenuPrimitive.SubTrigger>
-));
-DropdownMenuSubTrigger.displayName = DropdownMenuPrimitive.SubTrigger.displayName;
+  return context;
+}
 
-const DropdownMenuSubContent = React.forwardRef<
-  React.ElementRef<typeof DropdownMenuPrimitive.SubContent>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubContent>
->(({ className, ...props }, ref) => (
-  <DropdownMenuPrimitive.SubContent
-    ref={ref}
-    className={cn(
-      "z-50 min-w-[8rem] overflow-hidden rounded-lg border border-border bg-popover p-1 text-popover-foreground shadow-lg",
-      className
-    )}
-    {...props}
-  />
-));
-DropdownMenuSubContent.displayName = DropdownMenuPrimitive.SubContent.displayName;
+type DropdownMenuProps = {
+  children: ReactNode;
+  className?: string;
+};
 
-const DropdownMenuContent = React.forwardRef<
-  React.ElementRef<typeof DropdownMenuPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>
->(({ className, sideOffset = 4, ...props }, ref) => (
-  <DropdownMenuPrimitive.Portal>
-    <DropdownMenuPrimitive.Content
-      ref={ref}
-      sideOffset={sideOffset}
-      className={cn(
-        "z-50 min-w-[10rem] overflow-hidden rounded-lg border border-border bg-popover p-1 text-popover-foreground shadow-lg",
-        className
-      )}
-      {...props}
-    />
-  </DropdownMenuPrimitive.Portal>
-));
-DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName;
+function DropdownMenu({ children, className }: DropdownMenuProps) {
+  const [open, setOpen] = useState(false);
+  const [labelId, setLabelId] = useState<string | undefined>();
+  const triggerRef = useRef<HTMLElement | null>(null);
+  const menuRef = useRef<HTMLDivElement | null>(null);
+  const menuId = useId();
 
-const DropdownMenuItem = React.forwardRef<
-  React.ElementRef<typeof DropdownMenuPrimitive.Item>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item> & {
-    inset?: boolean;
+  const value = useMemo<DropdownMenuContextValue>(
+    () => ({ open, setOpen, triggerRef, menuRef, menuId, labelId, setLabelId }),
+    [labelId, menuId, open]
+  );
+
+  return (
+    <DropdownMenuContext.Provider value={value}>
+      <div className={cn("relative inline-flex", className)}>{children}</div>
+    </DropdownMenuContext.Provider>
+  );
+}
+
+type DropdownMenuTriggerProps = {
+  asChild?: boolean;
+  children: ReactElement;
+} & HTMLAttributes<HTMLElement>;
+
+const DropdownMenuTrigger = forwardRef<HTMLElement, DropdownMenuTriggerProps>(
+  ({ asChild, children, onClick, onKeyDown, ...props }, forwardedRef) => {
+    const { open, setOpen, triggerRef, menuId } = useDropdownMenuContext("DropdownMenuTrigger");
+
+    const assignRef = (node: HTMLElement | null) => {
+      triggerRef.current = node;
+      if (typeof forwardedRef === "function") {
+        forwardedRef(node);
+      } else if (forwardedRef) {
+        (forwardedRef as MutableRefObject<HTMLElement | null>).current = node;
+      }
+    };
+
+    const handleClick: MouseEventHandler<HTMLElement> = (event) => {
+      onClick?.(event);
+      setOpen((previous) => !previous);
+    };
+
+    const handleKeyDown: KeyboardEventHandler<HTMLElement> = (event) => {
+      onKeyDown?.(event);
+      if (event.defaultPrevented) return;
+      if (event.key === "Escape") {
+        setOpen(false);
+        return;
+      }
+      if (event.key === " " || event.key === "Enter" || event.key === "ArrowDown") {
+        event.preventDefault();
+        setOpen(true);
+      }
+    };
+
+    if (asChild) {
+      if (!isValidElement(children)) {
+        throw new Error("DropdownMenuTrigger with `asChild` expects a single React element child.");
+      }
+      return cloneElement(children, {
+        ...props,
+        "aria-controls": menuId,
+        "aria-expanded": open,
+        "aria-haspopup": "menu",
+        onClick: handleClick,
+        onKeyDown: handleKeyDown,
+        ref: assignRef
+      });
+    }
+
+    return (
+      <button
+        type="button"
+        ref={assignRef}
+        aria-controls={menuId}
+        aria-expanded={open}
+        aria-haspopup="menu"
+        onClick={handleClick}
+        onKeyDown={handleKeyDown}
+        {...props}
+      >
+        {children}
+      </button>
+    );
   }
->(({ className, inset, ...props }, ref) => (
-  <DropdownMenuPrimitive.Item
-    ref={ref}
-    className={cn(
-      "relative flex cursor-default select-none items-center rounded-md px-3 py-1.5 text-sm outline-none transition-colors focus:bg-muted focus:text-foreground",
-      inset && "pl-8",
-      className
-    )}
-    {...props}
-  />
-));
-DropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName;
+);
+DropdownMenuTrigger.displayName = "DropdownMenuTrigger";
 
-const DropdownMenuCheckboxItem = React.forwardRef<
-  React.ElementRef<typeof DropdownMenuPrimitive.CheckboxItem>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.CheckboxItem>
->(({ className, children, checked, ...props }, ref) => (
-  <DropdownMenuPrimitive.CheckboxItem
-    ref={ref}
-    className={cn(
-      "relative flex cursor-default select-none items-center rounded-md py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-muted focus:text-foreground",
-      className
-    )}
-    checked={checked}
-    {...props}
-  >
-    <span className="absolute left-2 flex h-4 w-4 items-center justify-center">
-      <DropdownMenuPrimitive.ItemIndicator>
-        <Check className="h-4 w-4" />
-      </DropdownMenuPrimitive.ItemIndicator>
-    </span>
-    {children}
-  </DropdownMenuPrimitive.CheckboxItem>
-));
-DropdownMenuCheckboxItem.displayName = DropdownMenuPrimitive.CheckboxItem.displayName;
+type DropdownMenuContentProps = {
+  sideOffset?: number;
+  align?: "start" | "center" | "end";
+  children: ReactNode;
+} & React.HTMLAttributes<HTMLDivElement>;
 
-const DropdownMenuRadioItem = React.forwardRef<
-  React.ElementRef<typeof DropdownMenuPrimitive.RadioItem>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.RadioItem>
->(({ className, children, ...props }, ref) => (
-  <DropdownMenuPrimitive.RadioItem
-    ref={ref}
-    className={cn(
-      "relative flex cursor-default select-none items-center rounded-md py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-muted focus:text-foreground",
-      className
-    )}
-    {...props}
-  >
-    <span className="absolute left-2 flex h-4 w-4 items-center justify-center">
-      <DropdownMenuPrimitive.ItemIndicator>
-        <div className="h-2 w-2 rounded-full bg-current" />
-      </DropdownMenuPrimitive.ItemIndicator>
-    </span>
-    {children}
-  </DropdownMenuPrimitive.RadioItem>
-));
-DropdownMenuRadioItem.displayName = DropdownMenuPrimitive.RadioItem.displayName;
+const DropdownMenuContent = forwardRef<HTMLDivElement, DropdownMenuContentProps>(
+  ({ className, sideOffset = 4, align = "center", children, style, ...props }, forwardedRef) => {
+    const { open, setOpen, triggerRef, menuRef, menuId, labelId } = useDropdownMenuContext("DropdownMenuContent");
 
-const DropdownMenuLabel = React.forwardRef<
-  React.ElementRef<typeof DropdownMenuPrimitive.Label>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Label> & {
-    inset?: boolean;
+    useEffect(() => {
+      if (!open) return;
+      const handlePointerDown = (event: MouseEvent | TouchEvent) => {
+        const target = event.target as Node;
+        if (menuRef.current?.contains(target) || triggerRef.current?.contains(target)) {
+          return;
+        }
+        setOpen(false);
+      };
+
+      const handleKeyDown = (event: KeyboardEvent) => {
+        if (event.key === "Escape") {
+          setOpen(false);
+          triggerRef.current?.focus();
+        }
+      };
+
+      document.addEventListener("mousedown", handlePointerDown);
+      document.addEventListener("touchstart", handlePointerDown);
+      document.addEventListener("keydown", handleKeyDown);
+      return () => {
+        document.removeEventListener("mousedown", handlePointerDown);
+        document.removeEventListener("touchstart", handlePointerDown);
+        document.removeEventListener("keydown", handleKeyDown);
+      };
+    }, [open, setOpen, triggerRef, menuRef]);
+
+    useEffect(() => {
+      if (open && menuRef.current) {
+        menuRef.current.focus();
+      }
+    }, [open, menuRef]);
+
+    const assignRef = (node: HTMLDivElement | null) => {
+      menuRef.current = node;
+      if (typeof forwardedRef === "function") {
+        forwardedRef(node);
+      } else if (forwardedRef) {
+        (forwardedRef as MutableRefObject<HTMLDivElement | null>).current = node;
+      }
+    };
+
+    if (!open) return null;
+
+    const alignmentClass =
+      align === "start" ? "left-0" : align === "end" ? "right-0" : "left-1/2 -translate-x-1/2";
+
+    return (
+      <div
+        ref={assignRef}
+        id={menuId}
+        role="menu"
+        tabIndex={-1}
+        aria-labelledby={labelId}
+        className={cn(
+          "absolute z-50 mt-2 min-w-[10rem] rounded-lg border border-border bg-popover p-1 text-popover-foreground shadow-lg focus:outline-none",
+          alignmentClass,
+          className
+        )}
+        style={{ marginTop: sideOffset, ...style }}
+        {...props}
+      >
+        {children}
+      </div>
+    );
   }
->(({ className, inset, ...props }, ref) => (
-  <DropdownMenuPrimitive.Label
-    ref={ref}
-    className={cn("px-2 py-1.5 text-xs font-medium text-muted-foreground", inset && "pl-8", className)}
-    {...props}
-  />
-));
-DropdownMenuLabel.displayName = DropdownMenuPrimitive.Label.displayName;
+);
+DropdownMenuContent.displayName = "DropdownMenuContent";
 
-const DropdownMenuSeparator = React.forwardRef<
-  React.ElementRef<typeof DropdownMenuPrimitive.Separator>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Separator>
->(({ className, ...props }, ref) => (
-  <DropdownMenuPrimitive.Separator
-    ref={ref}
-    className={cn("-mx-1 my-1 h-px bg-border", className)}
-    {...props}
-  />
-));
-DropdownMenuSeparator.displayName = DropdownMenuPrimitive.Separator.displayName;
+const DropdownMenuSeparator = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} role="separator" className={cn("-mx-1 my-1 h-px bg-border", className)} {...props} />
+  )
+);
+DropdownMenuSeparator.displayName = "DropdownMenuSeparator";
 
-const DropdownMenuShortcut = ({ className, ...props }: React.HTMLAttributes<HTMLSpanElement>) => {
+const DropdownMenuLabel = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement> & { inset?: boolean }>(
+  ({ className, inset, children, ...props }, ref) => {
+    const { setLabelId } = useDropdownMenuContext("DropdownMenuLabel");
+    const id = useId();
+
+    useEffect(() => {
+      setLabelId(id);
+      return () => setLabelId(undefined);
+    }, [id, setLabelId]);
+
+    return (
+      <div
+        ref={ref}
+        id={id}
+        role="presentation"
+        className={cn("px-2 py-1.5 text-xs font-medium text-muted-foreground", inset && "pl-8", className)}
+        {...props}
+      >
+        {children}
+      </div>
+    );
+  }
+);
+DropdownMenuLabel.displayName = "DropdownMenuLabel";
+
+type DropdownMenuGroupProps = {
+  children: ReactNode;
+  className?: string;
+} & HTMLAttributes<HTMLDivElement>;
+
+const DropdownMenuGroup = forwardRef<HTMLDivElement, DropdownMenuGroupProps>(
+  ({ className, children, ...props }, ref) => (
+    <div ref={ref} role="group" className={cn("flex flex-col", className)} {...props}>
+      {children}
+    </div>
+  )
+);
+DropdownMenuGroup.displayName = "DropdownMenuGroup";
+
+type DropdownMenuRadioGroupContextValue = {
+  value?: string;
+  onValueChange?: (value: string) => void;
+};
+
+const DropdownMenuRadioGroupContext = createContext<DropdownMenuRadioGroupContextValue | null>(null);
+
+type DropdownMenuRadioGroupProps = {
+  value?: string;
+  onValueChange?: (value: string) => void;
+  children: ReactNode;
+} & HTMLAttributes<HTMLDivElement>;
+
+const DropdownMenuRadioGroup = ({ value, onValueChange, children, className, ...props }: DropdownMenuRadioGroupProps) => {
+  const contextValue = useMemo<DropdownMenuRadioGroupContextValue>(
+    () => ({ value, onValueChange }),
+    [onValueChange, value]
+  );
+
+  return (
+    <DropdownMenuRadioGroupContext.Provider value={contextValue}>
+      <div role="radiogroup" className={cn("flex flex-col", className)} {...props}>
+        {children}
+      </div>
+    </DropdownMenuRadioGroupContext.Provider>
+  );
+};
+
+function useDropdownMenuRadioGroupContext(component: string) {
+  const context = useContext(DropdownMenuRadioGroupContext);
+  if (!context) {
+    throw new Error(`${component} must be used within a <DropdownMenuRadioGroup>`);
+  }
+  return context;
+}
+
+type DropdownMenuRadioItemProps = {
+  value: string;
+  inset?: boolean;
+  children: ReactNode;
+} & ButtonHTMLAttributes<HTMLButtonElement>;
+
+const DropdownMenuRadioItem = forwardRef<HTMLButtonElement, DropdownMenuRadioItemProps>(
+  ({ value, className, inset, children, disabled, onClick, ...props }, ref) => {
+    const { setOpen } = useDropdownMenuContext("DropdownMenuRadioItem");
+    const { value: selected, onValueChange } = useDropdownMenuRadioGroupContext("DropdownMenuRadioItem");
+    const isSelected = selected === value;
+
+    const handleClick: MouseEventHandler<HTMLButtonElement> = (event) => {
+      onClick?.(event);
+      if (event.defaultPrevented || disabled) return;
+      onValueChange?.(value);
+      setOpen(false);
+    };
+
+    return (
+      <button
+        ref={ref}
+        type="button"
+        role="menuitemradio"
+        aria-checked={isSelected}
+        data-state={isSelected ? "checked" : "unchecked"}
+        disabled={disabled}
+        className={cn(
+          "relative flex cursor-default select-none items-center rounded-md px-3 py-1.5 text-sm outline-none transition-colors focus:bg-muted focus:text-foreground disabled:cursor-not-allowed disabled:opacity-50",
+          inset && "pl-8",
+          className
+        )}
+        onClick={handleClick}
+        {...props}
+      >
+        <span className="absolute left-2 flex h-4 w-4 items-center justify-center" aria-hidden>
+          <span
+            className={cn("h-2 w-2 rounded-full", isSelected ? "bg-current" : "border border-muted-foreground/60")}
+          />
+        </span>
+        {children}
+      </button>
+    );
+  }
+);
+DropdownMenuRadioItem.displayName = "DropdownMenuRadioItem";
+
+type DropdownMenuCheckboxItemProps = {
+  checked?: boolean;
+  inset?: boolean;
+  children: ReactNode;
+} & React.ButtonHTMLAttributes<HTMLButtonElement>;
+
+const DropdownMenuCheckboxItem = forwardRef<HTMLButtonElement, DropdownMenuCheckboxItemProps>(
+  ({ checked, className, inset, children, disabled, onClick, ...props }, ref) => {
+    const { setOpen } = useDropdownMenuContext("DropdownMenuCheckboxItem");
+
+    const handleClick: MouseEventHandler<HTMLButtonElement> = (event) => {
+      onClick?.(event);
+      if (event.defaultPrevented || disabled) return;
+      setOpen(false);
+    };
+
+    return (
+      <button
+        ref={ref}
+        type="button"
+        role="menuitemcheckbox"
+        aria-checked={checked ?? false}
+        data-state={checked ? "checked" : "unchecked"}
+        disabled={disabled}
+        className={cn(
+          "relative flex cursor-default select-none items-center rounded-md py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-muted focus:text-foreground disabled:cursor-not-allowed disabled:opacity-50",
+          inset && "pl-8",
+          className
+        )}
+        onClick={handleClick}
+        {...props}
+      >
+        <span className="absolute left-2 flex h-4 w-4 items-center justify-center" aria-hidden>
+          <span
+            className={cn(
+              "inline-flex h-4 w-4 items-center justify-center rounded border border-muted-foreground/60 bg-background",
+              checked && "border-none bg-current text-background"
+            )}
+          >
+            {checked ? <span className="h-2 w-2 rounded-sm bg-background" /> : null}
+          </span>
+        </span>
+        {children}
+      </button>
+    );
+  }
+);
+DropdownMenuCheckboxItem.displayName = "DropdownMenuCheckboxItem";
+
+type DropdownMenuItemProps = {
+  inset?: boolean;
+  children: ReactNode;
+} & ButtonHTMLAttributes<HTMLButtonElement>;
+
+const DropdownMenuItem = forwardRef<HTMLButtonElement, DropdownMenuItemProps>(
+  ({ className, inset, children, disabled, onClick, ...props }, ref) => {
+    const { setOpen } = useDropdownMenuContext("DropdownMenuItem");
+
+    const handleClick: MouseEventHandler<HTMLButtonElement> = (event) => {
+      onClick?.(event);
+      if (event.defaultPrevented || disabled) return;
+      setOpen(false);
+    };
+
+    return (
+      <button
+        ref={ref}
+        type="button"
+        role="menuitem"
+        disabled={disabled}
+        className={cn(
+          "flex cursor-default select-none items-center rounded-md px-3 py-1.5 text-sm outline-none transition-colors focus:bg-muted focus:text-foreground disabled:cursor-not-allowed disabled:opacity-50",
+          inset && "pl-8",
+          className
+        )}
+        onClick={handleClick}
+        {...props}
+      >
+        {children}
+      </button>
+    );
+  }
+);
+DropdownMenuItem.displayName = "DropdownMenuItem";
+
+const DropdownMenuShortcut = ({ className, ...props }: SpanHTMLAttributes<HTMLSpanElement>) => {
   return <span className={cn("ml-auto text-xs tracking-tight text-muted-foreground", className)} {...props} />;
 };
 DropdownMenuShortcut.displayName = "DropdownMenuShortcut";
+
+const DropdownMenuSub = ({ children }: { children: ReactNode }) => children;
+const DropdownMenuPortal = ({ children }: { children: ReactNode }) => <>{children}</>;
+const DropdownMenuSubTrigger = DropdownMenuItem;
+const DropdownMenuSubContent = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>((props, ref) => (
+  <div ref={ref} {...props} />
+));
+DropdownMenuSubContent.displayName = "DropdownMenuSubContent";
 
 export {
   DropdownMenu,

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/next.config.js
+++ b/next.config.js
@@ -4,10 +4,19 @@ if (process.env.NEXT_PUBLIC_VERCEL_URL) {
   allowedOrigins.push(process.env.NEXT_PUBLIC_VERCEL_URL);
 }
 
+const isDevelopment = process.env.NODE_ENV !== "production";
+
+const scriptSrc = ["'self'", "'unsafe-inline'", "'wasm-unsafe-eval'", "'inline-speculation-rules'"];
+const styleSrc = ["'self'", "'unsafe-inline'"];
+
+if (isDevelopment) {
+  scriptSrc.push("'unsafe-eval'");
+}
+
 const cspDirectives = [
   "default-src 'self'",
-  "script-src 'self'",
-  "style-src 'self'",
+  `script-src ${scriptSrc.join(' ')}`,
+  `style-src ${styleSrc.join(' ')}`,
   "img-src 'self' data: blob:",
   "font-src 'self' data:",
   "connect-src 'self' https://plausible.io https://*.plausible.io",


### PR DESCRIPTION
## Summary
- rebuild the dropdown menu implementation to remove the missing `@radix-ui/react-dropdown-menu` dependency and keep the theme toggle functional
- update the theme toggle trigger styling to work with the custom dropdown components
- relax the Content-Security-Policy directives so Next.js hydration scripts run (and refresh Next.js generated type metadata)

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e8028c7da48323811fed50a0e45e92