### PR TITLE
Add community message board with voting

### DIFF
--- a/app/api/community/posts/[id]/replies/route.ts
+++ b/app/api/community/posts/[id]/replies/route.ts
@@ -1,0 +1,53 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import {
+  createCommunityReply,
+  getCommunityPostById,
+} from "@/lib/dataStore";
+import {
+  buildCommunityPostView,
+  buildCommunityReplyView,
+} from "@/lib/communityFeed";
+import { communityReplySchema } from "@/lib/zodSchemas";
+
+interface RouteParams {
+  params: { id: string };
+}
+
+export async function POST(request: Request, { params }: RouteParams) {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const postId = params.id;
+  const post = await getCommunityPostById(postId);
+  if (!post) {
+    return NextResponse.json({ error: "Post not found" }, { status: 404 });
+  }
+
+  const payload = await request.json();
+  const parsed = communityReplySchema.safeParse(payload);
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 });
+  }
+
+  const reply = await createCommunityReply({
+    postId,
+    authorId: session.user.id,
+    content: parsed.data.content,
+  });
+
+  if (!reply) {
+    return NextResponse.json({ error: "Post not found" }, { status: 404 });
+  }
+
+  const replyView = await buildCommunityReplyView(reply.id, session.user.id);
+  const postView = await buildCommunityPostView(postId, session.user.id);
+
+  if (!replyView || !postView) {
+    return NextResponse.json({ error: "Unable to load reply" }, { status: 500 });
+  }
+
+  return NextResponse.json({ reply: replyView, post: postView });
+}

--- a/app/api/community/posts/route.ts
+++ b/app/api/community/posts/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { createCommunityPost } from "@/lib/dataStore";
+import { buildCommunityFeed, buildCommunityPostView } from "@/lib/communityFeed";
+import { communityPostSchema } from "@/lib/zodSchemas";
+
+export async function GET() {
+  const session = await auth();
+  const posts = await buildCommunityFeed(session?.user?.id ?? null);
+  return NextResponse.json({ posts });
+}
+
+export async function POST(request: Request) {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const payload = await request.json();
+  const parsed = communityPostSchema.safeParse(payload);
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 });
+  }
+
+  const post = await createCommunityPost({
+    authorId: session.user.id,
+    title: parsed.data.title,
+    content: parsed.data.content,
+  });
+
+  const view = await buildCommunityPostView(post.id, session.user.id);
+  if (!view) {
+    return NextResponse.json({ error: "Unable to load post" }, { status: 500 });
+  }
+  return NextResponse.json({ post: view });
+}

--- a/app/api/community/votes/route.ts
+++ b/app/api/community/votes/route.ts
@@ -1,0 +1,64 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import {
+  getCommunityPostById,
+  getCommunityReplyById,
+  setCommunityVote,
+} from "@/lib/dataStore";
+import {
+  buildCommunityPostView,
+  buildCommunityReplyView,
+} from "@/lib/communityFeed";
+import { communityVoteSchema } from "@/lib/zodSchemas";
+
+export async function POST(request: Request) {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const payload = await request.json();
+  const parsed = communityVoteSchema.safeParse(payload);
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 });
+  }
+
+  const { targetType, targetId, value } = parsed.data;
+
+  if (targetType === "POST") {
+    const post = await getCommunityPostById(targetId);
+    if (!post) {
+      return NextResponse.json({ error: "Post not found" }, { status: 404 });
+    }
+    await setCommunityVote({
+      userId: session.user.id,
+      targetType,
+      targetId,
+      value,
+    });
+    const postView = await buildCommunityPostView(targetId, session.user.id);
+    if (!postView) {
+      return NextResponse.json({ error: "Unable to load post" }, { status: 500 });
+    }
+    return NextResponse.json({ post: postView });
+  }
+
+  const reply = await getCommunityReplyById(targetId);
+  if (!reply) {
+    return NextResponse.json({ error: "Reply not found" }, { status: 404 });
+  }
+
+  await setCommunityVote({
+    userId: session.user.id,
+    targetType,
+    targetId,
+    value,
+  });
+
+  const replyView = await buildCommunityReplyView(targetId, session.user.id);
+  if (!replyView) {
+    return NextResponse.json({ error: "Unable to load reply" }, { status: 500 });
+  }
+
+  return NextResponse.json({ reply: replyView });
+}

--- a/app/community/page.tsx
+++ b/app/community/page.tsx
@@ -1,0 +1,34 @@
+import CommunityBoard from "@/components/community/CommunityBoard";
+import { auth } from "@/lib/auth";
+import { buildCommunityFeed } from "@/lib/communityFeed";
+import type { Role } from "@/lib/prismaEnums";
+
+function resolveDisplayName(user: { name?: string | null; email?: string | null }) {
+  return user.name ?? user.email ?? "You";
+}
+
+export default async function CommunityPage() {
+  const session = await auth();
+  const posts = await buildCommunityFeed(session?.user?.id ?? null);
+
+  const currentUser = session?.user
+    ? {
+        id: session.user.id,
+        name: resolveDisplayName(session.user),
+        role: session.user.role as Role,
+      }
+    : null;
+
+  return (
+    <div className="mx-auto flex max-w-5xl flex-col gap-8">
+      <header className="space-y-4 text-center">
+        <h1 className="text-3xl font-bold tracking-tight sm:text-4xl">Community Message Board</h1>
+        <p className="text-base-content/80">
+          Trade booking leads, request feedback, and cheer on other performers. Share a post or upvote your
+          favorite replies to grow the funniest network on the internet.
+        </p>
+      </header>
+      <CommunityBoard currentUser={currentUser} initialPosts={posts} />
+    </div>
+  );
+}

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -12,6 +12,7 @@ const links = [
   { href: "/event-types", label: "Event Types" },
   { href: "/locations", label: "Locations" },
   { href: "/resources", label: "Resources" },
+  { href: "/community", label: "Community" },
   { href: "/help", label: "Help Center" },
   { href: "/about", label: "About" }
 ];

--- a/components/community/CommunityBoard.tsx
+++ b/components/community/CommunityBoard.tsx
@@ -1,0 +1,451 @@
+"use client";
+
+import { FormEvent, useMemo, useState } from "react";
+import { formatDistanceToNow } from "date-fns";
+import { ArrowBigDown, ArrowBigUp } from "lucide-react";
+import type { Role } from "@/lib/prismaEnums";
+import type {
+  CommunityPostView,
+  CommunityReplyView,
+} from "@/lib/communityFeed";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+
+interface CommunityBoardProps {
+  currentUser: { id: string; name: string; role: Role } | null;
+  initialPosts: CommunityPostView[];
+}
+
+type VoteDirection = 1 | -1;
+
+interface BannerState {
+  type: "success" | "error";
+  message: string;
+}
+
+function sortPosts(posts: CommunityPostView[]): CommunityPostView[] {
+  return [...posts].sort((a, b) => {
+    if (b.score !== a.score) {
+      return b.score - a.score;
+    }
+    return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
+  });
+}
+
+function formatRole(role: Role) {
+  return role.charAt(0) + role.slice(1).toLowerCase();
+}
+
+function formatTimestamp(timestamp: string) {
+  return formatDistanceToNow(new Date(timestamp), { addSuffix: true });
+}
+
+function makeVoteKey(targetType: "POST" | "REPLY", targetId: string) {
+  return `${targetType}:${targetId}`;
+}
+
+export default function CommunityBoard({ currentUser, initialPosts }: CommunityBoardProps) {
+  const [posts, setPosts] = useState(() => sortPosts(initialPosts));
+  const [title, setTitle] = useState("");
+  const [content, setContent] = useState("");
+  const [isSubmittingPost, setIsSubmittingPost] = useState(false);
+  const [postError, setPostError] = useState<string | null>(null);
+  const [banner, setBanner] = useState<BannerState | null>(null);
+  const [replyDrafts, setReplyDrafts] = useState<Record<string, string>>({});
+  const [replyErrors, setReplyErrors] = useState<Record<string, string | null>>({});
+  const [submittingReplyFor, setSubmittingReplyFor] = useState<string | null>(null);
+  const [pendingVotes, setPendingVotes] = useState<Set<string>>(new Set());
+
+  const isAuthenticated = Boolean(currentUser);
+
+  const postCount = useMemo(() => posts.length, [posts]);
+
+  function handleReplyChange(postId: string, value: string) {
+    setReplyDrafts((prev) => ({ ...prev, [postId]: value }));
+  }
+
+  function updatePostState(updated: CommunityPostView) {
+    setPosts((prev) => sortPosts(prev.map((post) => (post.id === updated.id ? updated : post))));
+  }
+
+  function replaceReplyInPost(updatedReply: CommunityReplyView) {
+    setPosts((prev) =>
+      sortPosts(
+        prev.map((post) => {
+          if (post.id !== updatedReply.postId) {
+            return post;
+          }
+          const updatedReplies = post.replies.map((reply) =>
+            reply.id === updatedReply.id ? updatedReply : reply
+          );
+          return { ...post, replies: updatedReplies };
+        })
+      )
+    );
+  }
+
+  function addReplyToPost(updatedPost: CommunityPostView) {
+    setPosts((prev) =>
+      sortPosts(prev.map((post) => (post.id === updatedPost.id ? updatedPost : post)))
+    );
+  }
+
+  function addPendingVote(key: string) {
+    setPendingVotes((prev) => {
+      const next = new Set(prev);
+      next.add(key);
+      return next;
+    });
+  }
+
+  function removePendingVote(key: string) {
+    setPendingVotes((prev) => {
+      const next = new Set(prev);
+      next.delete(key);
+      return next;
+    });
+  }
+
+  async function handleCreatePost(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setBanner(null);
+    setPostError(null);
+
+    if (!currentUser) {
+      setPostError("Sign in to share a post with the community.");
+      return;
+    }
+
+    const trimmedTitle = title.trim();
+    const trimmedContent = content.trim();
+
+    if (!trimmedTitle || !trimmedContent) {
+      setPostError("Add a title and message before posting.");
+      return;
+    }
+
+    setIsSubmittingPost(true);
+    try {
+      const response = await fetch("/api/community/posts", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ title: trimmedTitle, content: trimmedContent }),
+      });
+
+      if (!response.ok) {
+        const payload = await response.json().catch(() => null);
+        const message = payload?.error?.formErrors?.join(" ") ?? payload?.error ?? "Unable to publish your post.";
+        setPostError(typeof message === "string" ? message : "Unable to publish your post.");
+        return;
+      }
+
+      const data = (await response.json()) as { post?: CommunityPostView };
+      if (data.post) {
+        const newPost = data.post;
+        setPosts((prev) => sortPosts([newPost, ...prev.filter((post) => post.id !== newPost.id)]));
+        setTitle("");
+        setContent("");
+        setBanner({ type: "success", message: "Post shared with the community." });
+      }
+    } catch (error) {
+      setPostError("Something went wrong while publishing your post.");
+    } finally {
+      setIsSubmittingPost(false);
+    }
+  }
+
+  async function handleCreateReply(event: FormEvent<HTMLFormElement>, postId: string) {
+    event.preventDefault();
+    setBanner(null);
+    setReplyErrors((prev) => ({ ...prev, [postId]: null }));
+
+    if (!currentUser) {
+      setReplyErrors((prev) => ({ ...prev, [postId]: "Sign in to reply." }));
+      return;
+    }
+
+    const draft = (replyDrafts[postId] ?? "").trim();
+    if (!draft) {
+      setReplyErrors((prev) => ({ ...prev, [postId]: "Write a reply before sending." }));
+      return;
+    }
+
+    setSubmittingReplyFor(postId);
+    try {
+      const response = await fetch(`/api/community/posts/${postId}/replies`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ content: draft }),
+      });
+
+      if (!response.ok) {
+        const payload = await response.json().catch(() => null);
+        const message = payload?.error?.formErrors?.join(" ") ?? payload?.error ?? "Unable to send your reply.";
+        setReplyErrors((prev) => ({
+          ...prev,
+          [postId]: typeof message === "string" ? message : "Unable to send your reply.",
+        }));
+        return;
+      }
+
+      const data = (await response.json()) as {
+        post?: CommunityPostView;
+        reply?: CommunityReplyView;
+      };
+
+      if (data.post) {
+        addReplyToPost(data.post);
+      }
+      setReplyDrafts((prev) => ({ ...prev, [postId]: "" }));
+      setBanner({ type: "success", message: "Reply posted." });
+    } catch (error) {
+      setReplyErrors((prev) => ({ ...prev, [postId]: "Something went wrong while sending your reply." }));
+    } finally {
+      setSubmittingReplyFor(null);
+    }
+  }
+
+  async function handleVote(
+    targetType: "POST" | "REPLY",
+    targetId: string,
+    desiredDirection: VoteDirection,
+    currentVote: -1 | 0 | 1
+  ) {
+    if (!currentUser) {
+      setBanner({ type: "error", message: "Sign in to cast votes." });
+      return;
+    }
+
+    const nextValue = currentVote === desiredDirection ? 0 : desiredDirection;
+    const voteKey = makeVoteKey(targetType, targetId);
+
+    if (pendingVotes.has(voteKey)) {
+      return;
+    }
+
+    addPendingVote(voteKey);
+    setBanner(null);
+
+    try {
+      const response = await fetch("/api/community/votes", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ targetType, targetId, value: nextValue }),
+      });
+
+      if (!response.ok) {
+        const payload = await response.json().catch(() => null);
+        const message = payload?.error ?? "Unable to register your vote.";
+        setBanner({ type: "error", message: typeof message === "string" ? message : "Unable to register your vote." });
+        return;
+      }
+
+      const data = (await response.json()) as {
+        post?: CommunityPostView;
+        reply?: CommunityReplyView;
+      };
+
+      if (data.post) {
+        updatePostState(data.post);
+      }
+      if (data.reply) {
+        replaceReplyInPost(data.reply);
+      }
+    } catch (error) {
+      setBanner({ type: "error", message: "Something went wrong while recording your vote." });
+    } finally {
+      removePendingVote(voteKey);
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      {banner ? (
+        <div
+          role="status"
+          className={`alert ${banner.type === "success" ? "alert-success" : "alert-error"} flex items-center justify-between`}
+        >
+          <span>{banner.message}</span>
+          <Button variant="ghost" size="sm" onClick={() => setBanner(null)}>
+            Dismiss
+          </Button>
+        </div>
+      ) : null}
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-xl">Start a conversation</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <form className="space-y-4" onSubmit={handleCreatePost}>
+            <div className="space-y-2">
+              <label className="text-sm font-medium" htmlFor="post-title">
+                Title
+              </label>
+              <Input
+                id="post-title"
+                value={title}
+                onChange={(event) => setTitle(event.target.value)}
+                placeholder="Share a gig lead, question, or announcement"
+                disabled={isSubmittingPost}
+              />
+            </div>
+            <div className="space-y-2">
+              <label className="text-sm font-medium" htmlFor="post-content">
+                Message
+              </label>
+              <Textarea
+                id="post-content"
+                value={content}
+                onChange={(event) => setContent(event.target.value)}
+                placeholder="Add the full details so the community can jump in"
+                disabled={isSubmittingPost}
+                rows={5}
+              />
+            </div>
+            {postError ? <p className="text-sm text-error">{postError}</p> : null}
+            <div className="flex items-center justify-between">
+              <p className="text-sm text-base-content/70">
+                {isAuthenticated
+                  ? "Posts earn points when the community upvotes your ideas."
+                  : "Sign in to publish a post and join the discussion."}
+              </p>
+              <Button type="submit" disabled={!isAuthenticated || isSubmittingPost}>
+                {isSubmittingPost ? "Posting..." : "Publish"}
+              </Button>
+            </div>
+          </form>
+        </CardContent>
+      </Card>
+
+      <section aria-live="polite" className="space-y-4">
+        <header className="flex items-center justify-between">
+          <h2 className="text-xl font-semibold">Latest posts</h2>
+          <span className="text-sm text-base-content/70">{postCount} active {postCount === 1 ? "discussion" : "discussions"}</span>
+        </header>
+        {posts.length === 0 ? (
+          <Card>
+            <CardContent className="py-10 text-center text-base-content/70">
+              Be the first to share something with the community.
+            </CardContent>
+          </Card>
+        ) : (
+          posts.map((post) => {
+            const replyDraft = replyDrafts[post.id] ?? "";
+            const replyError = replyErrors[post.id] ?? null;
+            const isReplySubmitting = submittingReplyFor === post.id;
+            return (
+              <article key={post.id} className="rounded-xl border border-base-300 bg-base-100 p-4 shadow-sm">
+                <div className="flex gap-4">
+                  <div className="flex flex-col items-center gap-1">
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      className={`h-8 w-8 rounded-full ${post.userVote === 1 ? "bg-primary/10 text-primary" : "text-base-content/70"}`}
+                      onClick={() => handleVote("POST", post.id, 1, post.userVote)}
+                      disabled={pendingVotes.has(makeVoteKey("POST", post.id))}
+                      aria-label="Upvote post"
+                    >
+                      <ArrowBigUp className="h-5 w-5" />
+                    </Button>
+                    <span className="text-sm font-semibold">{post.score}</span>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      className={`h-8 w-8 rounded-full ${post.userVote === -1 ? "bg-secondary/10 text-secondary" : "text-base-content/70"}`}
+                      onClick={() => handleVote("POST", post.id, -1, post.userVote)}
+                      disabled={pendingVotes.has(makeVoteKey("POST", post.id))}
+                      aria-label="Downvote post"
+                    >
+                      <ArrowBigDown className="h-5 w-5" />
+                    </Button>
+                  </div>
+                  <div className="flex-1 space-y-3">
+                    <div className="flex flex-wrap items-center gap-2 text-xs text-base-content/70">
+                      <span className="font-medium text-base-content">
+                        {post.authorName} · {formatRole(post.authorRole)}
+                      </span>
+                      <span>•</span>
+                      <span>{formatTimestamp(post.createdAt)}</span>
+                    </div>
+                    <h3 className="text-lg font-semibold">{post.title}</h3>
+                    <p className="whitespace-pre-wrap text-base-content/90">{post.content}</p>
+                    <div className="rounded-lg border border-base-300 bg-base-200/40 p-3">
+                      <h4 className="text-sm font-semibold text-base-content/80">
+                        Replies · {post.replyCount}
+                      </h4>
+                      <div className="mt-3 space-y-3">
+                        {post.replies.length === 0 ? (
+                          <p className="text-sm text-base-content/70">No replies yet. Start the conversation!</p>
+                        ) : (
+                          post.replies.map((reply) => (
+                            <div key={reply.id} className="flex gap-3 rounded-lg border border-base-300/70 bg-base-100 p-3">
+                              <div className="flex flex-col items-center gap-1 pt-1">
+                                <Button
+                                  type="button"
+                                  variant="ghost"
+                                  size="icon"
+                                  className={`h-7 w-7 rounded-full ${reply.userVote === 1 ? "bg-primary/10 text-primary" : "text-base-content/60"}`}
+                                  onClick={() => handleVote("REPLY", reply.id, 1, reply.userVote)}
+                                  disabled={pendingVotes.has(makeVoteKey("REPLY", reply.id))}
+                                  aria-label="Upvote reply"
+                                >
+                                  <ArrowBigUp className="h-4 w-4" />
+                                </Button>
+                                <span className="text-xs font-semibold">{reply.score}</span>
+                                <Button
+                                  type="button"
+                                  variant="ghost"
+                                  size="icon"
+                                  className={`h-7 w-7 rounded-full ${reply.userVote === -1 ? "bg-secondary/10 text-secondary" : "text-base-content/60"}`}
+                                  onClick={() => handleVote("REPLY", reply.id, -1, reply.userVote)}
+                                  disabled={pendingVotes.has(makeVoteKey("REPLY", reply.id))}
+                                  aria-label="Downvote reply"
+                                >
+                                  <ArrowBigDown className="h-4 w-4" />
+                                </Button>
+                              </div>
+                              <div className="flex-1 space-y-1">
+                                <div className="flex flex-wrap items-center gap-2 text-xs text-base-content/70">
+                                  <span className="font-medium text-base-content">
+                                    {reply.authorName} · {formatRole(reply.authorRole)}
+                                  </span>
+                                  <span>•</span>
+                                  <span>{formatTimestamp(reply.createdAt)}</span>
+                                </div>
+                                <p className="whitespace-pre-wrap text-sm text-base-content/90">{reply.content}</p>
+                              </div>
+                            </div>
+                          ))
+                        )}
+                      </div>
+                      <form className="mt-3 space-y-2" onSubmit={(event) => handleCreateReply(event, post.id)}>
+                        <Textarea
+                          value={replyDraft}
+                          onChange={(event) => handleReplyChange(post.id, event.target.value)}
+                          placeholder={isAuthenticated ? "Add your reply" : "Sign in to reply"}
+                          rows={3}
+                          disabled={!isAuthenticated || isReplySubmitting}
+                        />
+                        {replyError ? <p className="text-xs text-error">{replyError}</p> : null}
+                        <div className="flex justify-end">
+                          <Button type="submit" size="sm" disabled={!isAuthenticated || isReplySubmitting}>
+                            {isReplySubmitting ? "Sending..." : "Reply"}
+                          </Button>
+                        </div>
+                      </form>
+                    </div>
+                  </div>
+                </div>
+              </article>
+            );
+          })
+        )}
+      </section>
+    </div>
+  );
+}

--- a/data/database.json
+++ b/data/database.json
@@ -509,5 +509,8 @@
       "enabled": true,
       "updatedAt": "2024-01-01T08:00:00.000Z"
     }
-  ]
+  ],
+  "communityPosts": [],
+  "communityReplies": [],
+  "communityVotes": []
 }

--- a/lib/communityFeed.ts
+++ b/lib/communityFeed.ts
@@ -1,0 +1,194 @@
+import {
+  listCommunityPosts,
+  listCommunityReplies,
+  listCommunityVotes,
+  listUsers,
+  type CommunityPost,
+  type CommunityReply,
+  type CommunityVote,
+  type User,
+} from "@/lib/dataStore";
+import type { Role } from "@/lib/prismaEnums";
+import type { CommunityVoteTarget } from "@/types/database";
+
+export interface CommunityReplyView {
+  id: string;
+  postId: string;
+  authorId: string;
+  authorRole: Role;
+  authorName: string;
+  content: string;
+  createdAt: string;
+  updatedAt: string;
+  score: number;
+  userVote: -1 | 0 | 1;
+}
+
+export interface CommunityPostView {
+  id: string;
+  authorId: string;
+  authorRole: Role;
+  authorName: string;
+  title: string;
+  content: string;
+  createdAt: string;
+  updatedAt: string;
+  score: number;
+  userVote: -1 | 0 | 1;
+  replyCount: number;
+  replies: CommunityReplyView[];
+}
+
+interface CommunityContext {
+  posts: CommunityPost[];
+  replies: CommunityReply[];
+  votes: CommunityVote[];
+  users: Map<string, User>;
+  voteTotals: Map<string, number>;
+  currentUserVotes: Map<string, -1 | 1>;
+  currentUserId: string | null;
+}
+
+function voteKey(targetType: CommunityVoteTarget, targetId: string) {
+  return `${targetType}:${targetId}`;
+}
+
+function getDisplayName(user: User | undefined | null) {
+  if (!user) return "Community member";
+  return user.name ?? user.email ?? "Community member";
+}
+
+function resolveRole(user: User | undefined | null): Role {
+  if (user?.role) {
+    return user.role;
+  }
+  return "FAN";
+}
+
+async function buildCommunityContext(currentUserId?: string | null): Promise<CommunityContext> {
+  const [posts, replies, votes, users] = await Promise.all([
+    listCommunityPosts(),
+    listCommunityReplies(),
+    listCommunityVotes(),
+    listUsers(),
+  ]);
+
+  const userMap = new Map(users.map((user) => [user.id, user] as const));
+
+  const totals = new Map<string, number>();
+  for (const vote of votes) {
+    const key = voteKey(vote.targetType, vote.targetId);
+    totals.set(key, (totals.get(key) ?? 0) + vote.value);
+  }
+
+  const currentVotes = new Map<string, -1 | 1>();
+  const normalizedUserId = currentUserId ?? null;
+  if (normalizedUserId) {
+    for (const vote of votes) {
+      if (vote.userId === normalizedUserId) {
+        currentVotes.set(voteKey(vote.targetType, vote.targetId), vote.value);
+      }
+    }
+  }
+
+  return {
+    posts,
+    replies,
+    votes,
+    users: userMap,
+    voteTotals: totals,
+    currentUserVotes: currentVotes,
+    currentUserId: normalizedUserId,
+  };
+}
+
+function resolveUserVote(
+  context: CommunityContext,
+  targetType: CommunityVoteTarget,
+  targetId: string
+): -1 | 0 | 1 {
+  if (!context.currentUserId) {
+    return 0;
+  }
+  return context.currentUserVotes.get(voteKey(targetType, targetId)) ?? 0;
+}
+
+function resolveScore(
+  context: CommunityContext,
+  targetType: CommunityVoteTarget,
+  targetId: string
+) {
+  return context.voteTotals.get(voteKey(targetType, targetId)) ?? 0;
+}
+
+function serializeReply(reply: CommunityReply, context: CommunityContext): CommunityReplyView {
+  const author = context.users.get(reply.authorId);
+  return {
+    id: reply.id,
+    postId: reply.postId,
+    authorId: reply.authorId,
+    authorRole: resolveRole(author),
+    authorName: getDisplayName(author),
+    content: reply.content,
+    createdAt: reply.createdAt.toISOString(),
+    updatedAt: reply.updatedAt.toISOString(),
+    score: resolveScore(context, "REPLY", reply.id),
+    userVote: resolveUserVote(context, "REPLY", reply.id),
+  };
+}
+
+function serializePost(post: CommunityPost, context: CommunityContext): CommunityPostView {
+  const author = context.users.get(post.authorId);
+  const replies = context.replies
+    .filter((reply) => reply.postId === post.id)
+    .map((reply) => serializeReply(reply, context));
+
+  return {
+    id: post.id,
+    authorId: post.authorId,
+    authorRole: resolveRole(author),
+    authorName: getDisplayName(author),
+    title: post.title,
+    content: post.content,
+    createdAt: post.createdAt.toISOString(),
+    updatedAt: post.updatedAt.toISOString(),
+    score: resolveScore(context, "POST", post.id),
+    userVote: resolveUserVote(context, "POST", post.id),
+    replyCount: replies.length,
+    replies,
+  };
+}
+
+export async function buildCommunityFeed(
+  currentUserId?: string | null
+): Promise<CommunityPostView[]> {
+  const context = await buildCommunityContext(currentUserId);
+  return context.posts
+    .map((post) => serializePost(post, context))
+    .sort((a, b) => {
+      if (b.score !== a.score) {
+        return b.score - a.score;
+      }
+      return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
+    });
+}
+
+export async function buildCommunityPostView(
+  postId: string,
+  currentUserId?: string | null
+): Promise<CommunityPostView | null> {
+  const context = await buildCommunityContext(currentUserId);
+  const post = context.posts.find((item) => item.id === postId);
+  if (!post) return null;
+  return serializePost(post, context);
+}
+
+export async function buildCommunityReplyView(
+  replyId: string,
+  currentUserId?: string | null
+): Promise<CommunityReplyView | null> {
+  const context = await buildCommunityContext(currentUserId);
+  const reply = context.replies.find((item) => item.id === replyId);
+  if (!reply) return null;
+  return serializeReply(reply, context);
+}

--- a/lib/zodSchemas.ts
+++ b/lib/zodSchemas.ts
@@ -204,6 +204,26 @@ export const communityBoardMessageUpdateSchema = z
   })
   .refine((value) => Object.keys(value).length > 0, { message: "Provide at least one field to update" });
 
+export const communityPostSchema = z.object({
+  title: z.string().trim().min(3).max(120),
+  content: z.string().trim().min(1).max(2000),
+});
+
+export const communityReplySchema = z.object({
+  content: z.string().trim().min(1).max(1500),
+});
+
+export const communityVoteSchema = z.object({
+  targetType: z.enum(["POST", "REPLY"] as const),
+  targetId: z.string().trim().min(1),
+  value: z
+    .number()
+    .int()
+    .refine((val) => val === -1 || val === 0 || val === 1, {
+      message: "Vote must be -1, 0, or 1",
+    }),
+});
+
 export const offerCreateSchema = z.object({
   threadId: z.string().trim().min(1),
   amount: z.number().int().positive(),

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -505,6 +505,9 @@ const snapshot: DatabaseSnapshot = {
   availability,
   reports: [],
   communityBoardMessages: [],
+  communityPosts: [],
+  communityReplies: [],
+  communityVotes: [],
   adSlots,
   featureFlags,
 };

--- a/tests/search.test.ts
+++ b/tests/search.test.ts
@@ -27,6 +27,9 @@ const emptySnapshot = (): DatabaseSnapshot => ({
   availability: [],
   reports: [],
   communityBoardMessages: [],
+  communityPosts: [],
+  communityReplies: [],
+  communityVotes: [],
   adSlots: [],
   featureFlags: [],
 });

--- a/types/database.ts
+++ b/types/database.ts
@@ -119,6 +119,36 @@ export interface CommunityBoardMessageRecord {
   updatedAt: string;
 }
 
+export interface CommunityPostRecord {
+  id: string;
+  authorId: string;
+  title: string;
+  content: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CommunityReplyRecord {
+  id: string;
+  postId: string;
+  authorId: string;
+  content: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export type CommunityVoteTarget = "POST" | "REPLY";
+
+export interface CommunityVoteRecord {
+  id: string;
+  targetType: CommunityVoteTarget;
+  targetId: string;
+  userId: string;
+  value: -1 | 1;
+  createdAt: string;
+  updatedAt: string;
+}
+
 export interface GigRecord {
   id: string;
   createdByUserId: string;
@@ -314,6 +344,9 @@ export interface DatabaseSnapshot {
   availability: AvailabilityRecord[];
   reports: ReportRecord[];
   communityBoardMessages: CommunityBoardMessageRecord[];
+  communityPosts: CommunityPostRecord[];
+  communityReplies: CommunityReplyRecord[];
+  communityVotes: CommunityVoteRecord[];
   adSlots: AdSlotRecord[];
   featureFlags: FeatureFlagRecord[];
 }


### PR DESCRIPTION
## Summary
- extend the datastore schema and helpers to store community posts, replies, and votes
- add community feed builder, API routes, and an interactive community board page with voting UI
- update seeds, cleanup utilities, and navigation to surface the new board

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e80c6e8b148323b76aebcce601c854