### PR TITLE
Remove non-core navigation tabs

### DIFF
--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -8,12 +8,9 @@ const links = [
   { href: "/", label: "Home" },
   { href: "/gigs", label: "Find Gigs" },
   { href: "/profiles", label: "Profiles" },
-  { href: "/services", label: "Services" },
   { href: "/event-types", label: "Event Types" },
-  { href: "/locations", label: "Locations" },
   { href: "/resources", label: "Resources" },
   { href: "/community", label: "Community" },
-  { href: "/help", label: "Help Center" },
   { href: "/about", label: "About" }
 ];
 


### PR DESCRIPTION
## Summary
- remove services, locations, and help center links from the global navigation to focus on core pages

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e8166385a0832386954c3cdd7f728d