### PR TITLE
Fix duplicate toDate helper in dataStore

### DIFF
--- a/lib/dataStore.ts
+++ b/lib/dataStore.ts
@@ -314,8 +314,15 @@ async function persist(snapshot: DatabaseSnapshot) {
   await fs.writeFile(DATABASE_PATH, JSON.stringify(snapshot, null, 2));
 }
 
-function toDate(value: string | null): Date | null {
-  return value ? new Date(value) : null;
+function toDate(value: string | null | undefined): Date | null {
+  if (!value) {
+    return null;
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+  return date;
 }
 
 function mapUser(record: UserRecord): User {
@@ -1417,17 +1424,6 @@ export async function countActiveApplicationsForGig(gigId: string): Promise<numb
   return snapshot.applications.filter(
     (application) => application.gigId === gigId && activeStatuses.includes(application.status)
   ).length;
-}
-
-function toDate(value: string | null | undefined): Date | null {
-  if (!value) {
-    return null;
-  }
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) {
-    return null;
-  }
-  return date;
 }
 
 function computeGigMetrics(snapshot: DatabaseSnapshot, gigId: string): GigMetrics {


### PR DESCRIPTION
## Summary
- update the shared `toDate` helper to handle undefined and invalid values safely
- remove the duplicate definition that caused the build error

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e83341bc488323acdbd22fd987ebef